### PR TITLE
Bump dev-dependency of criterion to 0.4

### DIFF
--- a/integer/Cargo.toml
+++ b/integer/Cargo.toml
@@ -48,7 +48,7 @@ default-features = false
 features = ["derive"]
 
 [dev-dependencies.criterion]
-version = "0.3.4"
+version = "0.4.0"
 features = ["html_reports"]
 
 [dev-dependencies.rand]


### PR DESCRIPTION
The new version of criterion has a bunch of convenient features. Prime examples are the `--quick` and `--quiet` flags:
```bash
$ time cargo bench --bench=benchmarks -- --quick --quiet to_hex
    Finished bench [optimized] target(s) in 0.03s
     Running benches/benchmarks.rs (/home/lemmih/coding/dashu/target/release/deps/benchmarks-bb085885476f3050)
to_hex/10               time:   [46.901 ns 47.163 ns 48.209 ns]
to_hex/100              time:   [88.315 ns 88.406 ns 88.767 ns]
to_hex/1000             time:   [1.1917 µs 1.1938 µs 1.2021 µs]
to_hex/10000            time:   [11.067 µs 11.075 µs 11.109 µs]
to_hex/100000           time:   [110.34 µs 110.88 µs 113.02 µs]
to_hex/1000000          time:   [1.1363 ms 1.1365 ms 1.1366 ms]

real	0m2.925s
user	0m45.749s
sys	0m1.102s
```
Without the `--quick` flag, those benchmarks would take 60s to finish rather than 2.9s. And without the `--quiet` flag, the results would be harder to read.
