### PR TITLE
Refactor `Memory` to reduce unsafe code

### DIFF
--- a/integer/src/div/divide_conquer.rs
+++ b/integer/src/div/divide_conquer.rs
@@ -9,11 +9,10 @@ use crate::{
     mul,
     Sign::*,
 };
-use alloc::alloc::Layout;
 use static_assertions::const_assert;
 
 /// Memory requirement for division.
-pub fn memory_requirement_exact(lhs_len: usize, rhs_len: usize) -> Layout {
+pub fn memory_requirement_exact(lhs_len: usize, rhs_len: usize) -> usize {
     assert!(lhs_len >= rhs_len);
     // We need space for multiplications summing up to rhs.len(),
     // and at most lhs_len - rhs_len long.

--- a/integer/src/div/mod.rs
+++ b/integer/src/div/mod.rs
@@ -4,11 +4,10 @@ use crate::{
     arch::word::{DoubleWord, Word},
     helper_macros::debug_assert_zero,
     math::{shl_dword, shr_word, FastDivideNormalized, FastDivideNormalized2},
-    memory::{self, Memory},
+    memory::Memory,
     primitive::{double_word, extend_word, highest_dword, lowest_dword, split_dword, WORD_BITS},
     shift,
 };
-use alloc::alloc::Layout;
 
 mod divide_conquer;
 mod simple;
@@ -231,10 +230,10 @@ pub(crate) fn fast_rem_by_normalized_dword(
 }
 
 /// Memory requirement for division.
-pub fn memory_requirement_exact(lhs_len: usize, rhs_len: usize) -> Layout {
+pub fn memory_requirement_exact(lhs_len: usize, rhs_len: usize) -> usize {
     assert!(lhs_len >= rhs_len && rhs_len >= 2);
     if rhs_len <= THRESHOLD_SIMPLE || lhs_len - rhs_len <= THRESHOLD_SIMPLE {
-        memory::zero_layout()
+        0
     } else {
         divide_conquer::memory_requirement_exact(lhs_len, rhs_len)
     }

--- a/integer/src/gcd/mod.rs
+++ b/integer/src/gcd/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     primitive::{extend_word, shrink_dword, PrimitiveSigned},
     Sign,
 };
-use alloc::alloc::Layout;
 use dashu_base::ExtendedGcd;
 
 mod lehmer;
@@ -30,7 +29,7 @@ pub fn gcd_in_place(lhs: &mut [Word], rhs: &mut [Word], memory: &mut Memory) -> 
 }
 
 /// Memory requirement for GCD.
-pub fn memory_requirement_exact(lhs_len: usize, rhs_len: usize) -> Layout {
+pub fn memory_requirement_exact(lhs_len: usize, rhs_len: usize) -> usize {
     lehmer::memory_requirement_up_to(lhs_len, rhs_len)
 }
 
@@ -53,7 +52,7 @@ pub fn gcd_ext_in_place(
 }
 
 /// Memory requirement for extended GCD.
-pub fn memory_requirement_ext_exact(lhs_len: usize, rhs_len: usize) -> Layout {
+pub fn memory_requirement_ext_exact(lhs_len: usize, rhs_len: usize) -> usize {
     lehmer::memory_requirement_ext_up_to(lhs_len, rhs_len)
 }
 

--- a/integer/src/modular/mul.rs
+++ b/integer/src/modular/mul.rs
@@ -11,7 +11,6 @@ use crate::{
     primitive::{extend_word, locate_top_word_plus_one, split_dword},
     shift, sqr,
 };
-use alloc::alloc::Layout;
 use core::ops::{Deref, Mul, MulAssign};
 use num_modular::Reducer;
 
@@ -115,14 +114,11 @@ impl<'a> Reduced<'a> {
     }
 }
 
-pub(crate) fn mul_memory_requirement(ring: &ConstLargeDivisor) -> Layout {
+pub(crate) fn mul_memory_requirement(ring: &ConstLargeDivisor) -> usize {
     let n = ring.normalized_divisor.len();
-    memory::add_layout(
-        memory::array_layout::<Word>(2 * n),
-        memory::max_layout(
-            mul::memory_requirement_exact(2 * n, n),
-            div::memory_requirement_exact(2 * n, n),
-        ),
+    memory::add_capacity(
+        2 * n,
+        mul::memory_requirement_exact(2 * n, n).max(div::memory_requirement_exact(2 * n, n)),
     )
 }
 
@@ -142,7 +138,7 @@ pub(crate) fn mul_normalized<'a>(
     let nb = locate_top_word_plus_one(b);
 
     // product = a * b
-    let (product, mut memory) = memory.allocate_slice_fill::<Word>(n.max(na + nb), 0);
+    let (product, mut memory) = memory.allocate_slice_fill(n.max(na + nb), 0);
     if na | nb == 0 {
         return product;
     } else if na == 1 && nb == 1 {
@@ -198,7 +194,7 @@ pub(crate) fn sqr_normalized<'a>(
     let na = locate_top_word_plus_one(a);
 
     // product = a * a
-    let (product, mut memory) = memory.allocate_slice_fill::<Word>(n.max(na * 2), 0);
+    let (product, mut memory) = memory.allocate_slice_fill(n.max(na * 2), 0);
     if na == 0 {
         return product;
     } else if na == 1 {

--- a/integer/src/modular/pow.rs
+++ b/integer/src/modular/pow.rs
@@ -140,13 +140,10 @@ mod large {
             .checked_mul(n)
             .unwrap_or_else(|| panic_allocate_too_much());
 
-        let memory_requirement = memory::add_layout(
-            memory::array_layout::<Word>(table_words),
-            mul_memory_requirement(ring),
-        );
+        let memory_requirement = memory::add_capacity(table_words, mul_memory_requirement(ring));
         let mut allocation = MemoryAllocation::new(memory_requirement);
         let mut memory = allocation.memory();
-        let (table, mut memory) = memory.allocate_slice_fill::<Word>(table_words, 0);
+        let (table, mut memory) = memory.allocate_slice_fill(table_words, 0);
 
         // val = raw^2
         let mut val = raw.clone();

--- a/integer/src/mul/karatsuba.rs
+++ b/integer/src/mul/karatsuba.rs
@@ -5,11 +5,10 @@ use crate::{
     arch::word::{SignedWord, Word},
     helper_macros::debug_assert_zero,
     math,
-    memory::{self, Memory},
+    memory::Memory,
     mul::{self, helpers},
     Sign::{self, *},
 };
-use alloc::alloc::Layout;
 
 // We must have 3 * floor((n+1)/2) <= 2n.
 //
@@ -21,7 +20,7 @@ pub const MIN_LEN: usize = 3;
 /// Temporary memory required for multiplication.
 ///
 /// n bounds the length of the Smaller factor in words.
-pub fn memory_requirement_up_to(n: usize) -> Layout {
+pub fn memory_requirement_up_to(n: usize) -> usize {
     /* We prove by induction that:
      * f(n) <= 2n + 2 log_2 (n-1)
      *
@@ -33,8 +32,7 @@ pub fn memory_requirement_up_to(n: usize) -> Layout {
      */
 
     // Use 2n + 2 ceil log_2 n.
-    let num_words = 2 * n + 2 * (math::ceil_log2(n) as usize);
-    memory::array_layout::<Word>(num_words)
+    2 * n + 2 * (math::ceil_log2(n) as usize)
 }
 
 /// c += sign * a * b
@@ -91,7 +89,7 @@ pub fn add_signed_mul_same_len(
     {
         // c_0 += a_lo * b_lo
         // c_1 += a_lo * b_lo
-        let (c_lo, mut memory) = memory.allocate_slice_fill::<Word>(2 * mid, 0);
+        let (c_lo, mut memory) = memory.allocate_slice_fill(2 * mid, 0);
         debug_assert_zero!(mul::add_signed_mul_same_len(c_lo, Positive, a_lo, b_lo, &mut memory));
         carry_c0 += add::add_signed_same_len_in_place(&mut c[..2 * mid], sign, c_lo);
         carry_c1 += add::add_signed_same_len_in_place(&mut c[mid..3 * mid], sign, c_lo);
@@ -99,7 +97,7 @@ pub fn add_signed_mul_same_len(
     {
         // c_2 += a_hi * b_hi
         // c_1 += a_hi * b_hi
-        let (c_hi, mut memory) = memory.allocate_slice_fill::<Word>(2 * (n - mid), 0);
+        let (c_hi, mut memory) = memory.allocate_slice_fill(2 * (n - mid), 0);
         debug_assert_zero!(mul::add_signed_mul_same_len(c_hi, Positive, a_hi, b_hi, &mut memory));
         carry += add::add_signed_same_len_in_place(&mut c[2 * mid..], sign, c_hi);
         carry_c1 += add::add_signed_in_place(&mut c[mid..3 * mid], sign, c_hi);

--- a/integer/src/mul/mod.rs
+++ b/integer/src/mul/mod.rs
@@ -5,11 +5,10 @@ use crate::{
     arch::word::{DoubleWord, SignedWord, Word},
     helper_macros::debug_assert_zero,
     math,
-    memory::{self, Memory},
+    memory::Memory,
     primitive::{double_word, extend_word, split_dword},
     Sign,
 };
-use alloc::alloc::Layout;
 use core::mem;
 use static_assertions::const_assert;
 
@@ -158,9 +157,9 @@ pub fn sub_mul_word_same_len_in_place(words: &mut [Word], mult: Word, rhs: &[Wor
 }
 
 /// Temporary scratch space required for multiplication.
-pub fn memory_requirement_up_to(_total_len: usize, smaller_len: usize) -> Layout {
+pub fn memory_requirement_up_to(_total_len: usize, smaller_len: usize) -> usize {
     if smaller_len <= THRESHOLD_SIMPLE {
-        memory::zero_layout()
+        0
     } else if smaller_len <= THRESHOLD_KARATSUBA {
         karatsuba::memory_requirement_up_to(smaller_len)
     } else {
@@ -169,7 +168,7 @@ pub fn memory_requirement_up_to(_total_len: usize, smaller_len: usize) -> Layout
 }
 
 /// Temporary scratch space required for multiplication.
-pub fn memory_requirement_exact(total_len: usize, smaller_len: usize) -> Layout {
+pub fn memory_requirement_exact(total_len: usize, smaller_len: usize) -> usize {
     memory_requirement_up_to(total_len, smaller_len)
 }
 

--- a/integer/src/mul/toom_3.rs
+++ b/integer/src/mul/toom_3.rs
@@ -6,12 +6,11 @@ use crate::{
     div,
     helper_macros::debug_assert_zero,
     math,
-    memory::{self, Memory},
+    memory::Memory,
     mul::{self, helpers},
     shift,
     Sign::{self, *},
 };
-use alloc::alloc::Layout;
 
 /* We must have:
  * 2 * (n+2) <= n
@@ -31,7 +30,7 @@ pub const MIN_LEN: usize = 16;
 /// Temporary memory required for multiplication.
 ///
 /// n bounds the length of the Smaller factor in words.
-pub fn memory_requirement_up_to(n: usize) -> Layout {
+pub fn memory_requirement_up_to(n: usize) -> usize {
     /* In each level of recursion we use:
      * a_eval: n3 + 1
      * b_eval: n3 + 1
@@ -54,8 +53,7 @@ pub fn memory_requirement_up_to(n: usize) -> Layout {
 
     // Note: the recurence also works when we transition to Karatsuba, because
     // Karatsuba memory requirements are Smaller.
-    let num_words = 4 * n + 13 * (math::ceil_log2(n) as usize);
-    memory::array_layout::<Word>(num_words)
+    4 * n + 13 * (math::ceil_log2(n) as usize)
 }
 
 /// c += sign * a * b

--- a/integer/src/pow.rs
+++ b/integer/src/pow.rs
@@ -134,8 +134,8 @@ pub(crate) mod repr {
         let (exp, exp_rem) = exp.div_rem(wexp);
         let mut res = Buffer::allocate(exp + 1); // result is at most exp + 1 words
         let mut allocation = MemoryAllocation::new(
-            memory::add_layout(
-                memory::array_layout::<Word>(exp / 2 + 1), // store res before squaring
+            memory::add_capacity(
+                exp / 2 + 1, // store res before squaring
                 sqr::memory_requirement_exact(exp / 2 + 1),
             ), // memory for squaring
         );
@@ -177,8 +177,8 @@ pub(crate) mod repr {
 
         let mut res = Buffer::allocate(2 * exp); // result is at most 2 * exp words
         let mut allocation = MemoryAllocation::new(
-            memory::add_layout(
-                memory::array_layout::<Word>(exp), // store res before squaring
+            memory::add_capacity(
+                exp, // store res before squaring
                 sqr::memory_requirement_exact(exp),
             ), // memory for squaring
         );

--- a/integer/src/root.rs
+++ b/integer/src/root.rs
@@ -3,25 +3,21 @@ use crate::{
     arch::word::{DoubleWord, Word},
     div,
     math::FastDivideNormalized2,
-    memory::{self, Memory},
+    memory::Memory,
     mul::add_mul_word_in_place,
     primitive::{double_word, extend_word, highest_dword, split_dword, WORD_BITS},
     shift::shr_in_place_with_carry,
     sqr,
 };
-use alloc::alloc::Layout;
 use dashu_base::{DivRem, SquareRootRem};
 
 // n is the size of the output, or half the size of the input
-pub fn memory_requirement_sqrt_rem(n: usize) -> Layout {
+pub fn memory_requirement_sqrt_rem(n: usize) -> usize {
     if n == 2 {
-        memory::zero_layout()
+        0
     } else {
         // We need to perform a squaring with n words and an n by n/2 division
-        memory::max_layout(
-            sqr::memory_requirement_exact(n),
-            div::memory_requirement_exact(n, n - n / 2),
-        )
+        sqr::memory_requirement_exact(n).max(div::memory_requirement_exact(n, n - n / 2))
     }
 }
 

--- a/integer/src/sqr/mod.rs
+++ b/integer/src/sqr/mod.rs
@@ -1,22 +1,15 @@
 //! Square.
 
-use alloc::alloc::Layout;
-
-use crate::{
-    arch::word::Word,
-    helper_macros::debug_assert_zero,
-    memory::{self, Memory},
-    mul, Sign,
-};
+use crate::{arch::word::Word, helper_macros::debug_assert_zero, memory::Memory, mul, Sign};
 
 mod simple;
 
 /// If operand length <= this, simple squaring will be used.
 const MAX_LEN_SIMPLE: usize = 30;
 
-pub fn memory_requirement_exact(len: usize) -> Layout {
+pub fn memory_requirement_exact(len: usize) -> usize {
     if len <= MAX_LEN_SIMPLE {
-        memory::zero_layout()
+        0
     } else {
         mul::memory_requirement_up_to(2 * len, len)
     }


### PR DESCRIPTION
Refactor `Memory` to avoid dealing with manual allocations, raw pointers and memory layouts.

Now it uses a `Vec` (with length zero and desired capacity) and `Vec::spare_capacity_mut` to access the allocated capacity.
