### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,7 +130,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -p benchmark
+          args: -p benchmark --features gmp
 
   build-aarch64:
     name: Build aarch64

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -22,7 +22,7 @@ std = []
 
 [dev-dependencies]
 rand = { version = "0.8.3" }
-criterion = { version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [[bench]]
 name = "benchmarks"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -11,6 +11,6 @@ num-bigint = "0.4.3"
 ramp = { version = "0.7.0", optional = true }
 rug = "1.13.0"
 rust-gmp = "0.5.0"
-malachite-base = "0.2.2"
-malachite-nz = "0.2.2"
+malachite-base = "0.4.2"
+malachite-nz = "0.4.2"
 dashu-int = { path = "../integer" }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -6,11 +6,14 @@ publish = false
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
-ibig = "0.3.4"
-num-bigint = "0.4.3"
+ibig = "0.3.6"
+num-bigint = "0.4.4"
 ramp = { version = "0.7.0", optional = true }
-rug = "1.13.0"
-rust-gmp = "0.5.0"
+rug = { version = "1.22.0", optional = true }
+rust-gmp = { version = "0.5.0", optional = true }
 malachite-base = "0.4.2"
 malachite-nz = "0.4.2"
 dashu-int = { path = "../integer" }
+
+[features]
+gmp = ["rug", "rust-gmp"]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "benchmark"
 version = "0.0.0"
+edition = "2021"
 publish = false
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "4.4.6", features = ["derive"] }
 ibig = "0.3.4"
 num-bigint = "0.4.3"
 ramp = { version = "0.7.0", optional = true }

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,14 +4,13 @@ Benchmarks for Rust big integer implementations. The code is adopted from [bigin
 
 | Library                                               | Version | Notes                                                  |
 | --------------                                        | ------- | ------                                                 |
-| [rug](https://crates.io/crates/rug)                   | 1.16.0  | Links to libc and [GMP](https://gmplib.org/)           |
+| [dashu](https://crates.io/crates/dashu)               | 0.4.0   | Pure Rust, no_std                                      |
+| [rug](https://crates.io/crates/rug)                   | 1.22.0  | Links to libc and [GMP](https://gmplib.org/)           |
 | [rust-gmp](https://crates.io/crates/rust-gmp)         | 0.5.0   | Links to libc and [GMP](https://gmplib.org/)           |
-| [ibig](https://crates.io/crates/ibig)                 | 0.3.5   | Pure Rust, no_std                                      |
-| [dashu](https://crates.io/crates/dashu)               | 0.1.0   | Pure Rust, no_std                                   |
-| [malachite-nz](https://crates.io/crates/malachite-nz) | 0.2.2   | Pure Rust, LGPL, derived from GMP and FLINT            |
-| [num-bigint](https://crates.io/crates/num-bigint)     | 0.4.3   | Pure Rust, no_std                                      |
+| [ibig](https://crates.io/crates/ibig)                 | 0.3.6   | Pure Rust, no_std                                      |
+| [malachite-nz](https://crates.io/crates/malachite-nz) | 0.4.2   | Pure Rust, LGPL, derived from GMP and FLINT            |
+| [num-bigint](https://crates.io/crates/num-bigint)     | 0.4.4   | Pure Rust, no_std                                      |
 | [ramp](https://crates.io/crates/ramp)                 | 0.7.0   | Requires nightly Rust, uses x86_64 assembly            |
-
 
 ## Tasks
 
@@ -20,3 +19,8 @@ Benchmarks for Rust big integer implementations. The code is adopted from [bigin
 | `e`       | n digits of e                 | Hard       | Binary splitting      | addition, multiplication, division, exponentiation, base conversion |
 | `fib`     | n-th Fibonnaci number         | Medium     | Matrix exponentiation | addition, multiplication, base conversion |
 | `fib_hex` | n-th Fibonnaci number in hex  | Easy       | Matrix exponentiation | addition, multiplication |
+
+## Usage examples
+
+- Print results: `cargo run -- --lib ibig --lib dashu --lib num-bigint --lib malachite --task e -n 100 print`
+- Run the benchmark: `cargo run -- --lib ibig --lib dashu --lib num-bigint --lib malachite --task e -n 1000000 exec`

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -29,10 +29,13 @@ enum Lib {
     Dashu,
     #[value(name = "num-bigint")]
     NumBigint,
+    #[cfg(feature = "ramp")]
     #[value(name = "ramp")]
     Ramp,
+    #[cfg(feature = "rug")]
     #[value(name = "rug")]
     Rug,
+    #[cfg(feature = "rust-gmp")]
     #[value(name = "rust-gmp")]
     RustGmp,
     #[value(name = "malachite")]
@@ -53,8 +56,8 @@ enum Task {
 enum SubCommand {
     #[command(name = "print")]
     Print,
-    #[command(name = "benchmark")]
-    Benchmark,
+    #[command(name = "exec")]
+    Execute,
 }
 
 fn main() {
@@ -62,7 +65,7 @@ fn main() {
 
     match args.subcommand {
         SubCommand::Print => command_print(&args.libs, args.task, args.n),
-        SubCommand::Benchmark => command_benchmark(&args.libs, args.task, args.n),
+        SubCommand::Execute => command_benchmark(&args.libs, args.task, args.n),
     }
 }
 
@@ -132,9 +135,9 @@ fn run_task(lib: Lib, task: Task, n: u32, iter: u32) -> (String, Duration) {
         Lib::NumBigint => run_task_using::<num_bigint::BigUint>(task, n, iter),
         #[cfg(feature = "ramp")]
         Lib::Ramp => run_task_using::<ramp::Int>(task, n, iter),
-        #[cfg(not(feature = "ramp"))]
-        Lib::Ramp => unreachable!("ramp is only supported with nightly rust!"),
+        #[cfg(feature = "rug")]
         Lib::Rug => run_task_using::<rug::Integer>(task, n, iter),
+        #[cfg(feature = "rust_gmp")]
         Lib::RustGmp => run_task_using::<gmp::mpz::Mpz>(task, n, iter),
         Lib::Malachite => run_task_using::<malachite_nz::natural::Natural>(task, n, iter),
     }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -1,90 +1,99 @@
-extern crate clap;
-use clap::{App, AppSettings, Arg, SubCommand};
-use number::Number;
 use std::time::{Duration, Instant};
+
+use clap::ValueEnum as _;
+use number::Number;
 
 mod digits_of_e;
 mod fib;
 mod number;
 
+#[derive(clap::Parser)]
+#[command(name = "Bigint benchmarks")]
+struct Cli {
+    #[arg(long = "lib", required = true)]
+    libs: Vec<Lib>,
+    #[arg(long = "task")]
+    task: Task,
+    #[arg(short = 'n')]
+    n: u32,
+
+    #[command(subcommand)]
+    subcommand: SubCommand,
+}
+
+#[derive(Copy, Clone, clap::ValueEnum)]
+enum Lib {
+    #[value(name = "ibig")]
+    IBig,
+    #[value(name = "dashu")]
+    Dashu,
+    #[value(name = "num-bigint")]
+    NumBigint,
+    #[value(name = "ramp")]
+    Ramp,
+    #[value(name = "rug")]
+    Rug,
+    #[value(name = "rust-gmp")]
+    RustGmp,
+    #[value(name = "malachite")]
+    Malachite,
+}
+
+#[derive(Copy, Clone, clap::ValueEnum)]
+enum Task {
+    #[value(name = "e")]
+    E,
+    #[value(name = "fib")]
+    Fib,
+    #[value(name = "fib_hex")]
+    FibHex,
+}
+
+#[derive(clap::Subcommand)]
+enum SubCommand {
+    #[command(name = "print")]
+    Print,
+    #[command(name = "benchmark")]
+    Benchmark,
+}
+
 fn main() {
-    let args = App::new("Bigint benchmarks")
-        .arg(
-            Arg::with_name("lib")
-                .long("lib")
-                .possible_values(&[
-                    "ibig",
-                    "dashu",
-                    "num-bigint",
-                    "ramp",
-                    "rug",
-                    "rust-gmp",
-                    "malachite",
-                ])
-                .multiple(true)
-                .number_of_values(1)
-                .required(true)
-                .min_values(1),
-        )
-        .arg(
-            Arg::with_name("task")
-                .long("task")
-                .takes_value(true)
-                .possible_values(&["e", "fib", "fib_hex"])
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("n")
-                .short("n")
-                .takes_value(true)
-                .required(true),
-        )
-        .subcommand(SubCommand::with_name("print"))
-        .subcommand(SubCommand::with_name("benchmark"))
-        .settings(&[AppSettings::SubcommandRequired])
-        .get_matches();
+    let args: Cli = clap::Parser::parse();
 
-    let libs: Vec<String> = args
-        .values_of("lib")
-        .unwrap()
-        .map(|s| s.to_string())
-        .collect();
-    let task = args.value_of("task").unwrap();
-    let n: u32 = args.value_of("n").unwrap().parse().expect("invalid n");
-
-    match args.subcommand() {
-        ("print", _) => command_print(&libs, task, n),
-        ("benchmark", _) => command_benchmark(&libs, task, n),
-        _ => unreachable!(),
+    match args.subcommand {
+        SubCommand::Print => command_print(&args.libs, args.task, args.n),
+        SubCommand::Benchmark => command_benchmark(&args.libs, args.task, args.n),
     }
 }
 
-fn command_print(libs: &[String], task: &str, n: u32) {
+fn command_print(libs: &[Lib], task: Task, n: u32) {
     let mut answer: Option<String> = None;
-    for lib_name in libs {
-        let (a, _) = run_task(lib_name, task, n, 1);
+    for &lib in libs {
+        let lib_name = lib.to_possible_value().unwrap();
+        let (a, _) = run_task(lib, task, n, 1);
         match &answer {
             None => {
                 println!("answer = {}", a);
-                println!("{:10} agrees", lib_name);
+                println!("{:10} agrees", lib_name.get_name());
                 answer = Some(a);
             }
             Some(ans) => {
                 if *ans == a {
-                    println!("{:10} agrees", lib_name);
+                    println!("{:10} agrees", lib_name.get_name());
                 } else {
-                    println!("{} disagrees!", lib_name);
+                    println!("{} disagrees!", lib_name.get_name());
                 }
             }
         }
     }
 }
 
-fn command_benchmark(libs: &[String], task: &str, n: u32) {
+fn command_benchmark(libs: &[Lib], task: Task, n: u32) {
     let mut answer: Option<String> = None;
-    let mut results: Vec<(&String, Duration)> = Vec::new();
-    for lib_name in libs {
-        println!("{}", lib_name);
+    let mut results: Vec<(Lib, Duration)> = Vec::new();
+    for &lib in libs {
+        let lib_name = lib.to_possible_value().unwrap();
+        println!("{}", lib_name.get_name());
         // Take the median of 5 attempts, each attempt at least 10 seconds.
         let mut durations: Vec<Duration> = Vec::new();
         for sample_number in 0..5 {
@@ -92,7 +101,7 @@ fn command_benchmark(libs: &[String], task: &str, n: u32) {
             let mut duration = Duration::from_secs(0);
             while duration < Duration::from_secs(10) {
                 let i = iter.max(1);
-                let (a, d) = run_task(lib_name, task, n, i);
+                let (a, d) = run_task(lib, task, n, i);
                 match &answer {
                     None => answer = Some(a),
                     Some(ans) => assert!(*ans == a),
@@ -106,41 +115,39 @@ fn command_benchmark(libs: &[String], task: &str, n: u32) {
         }
         durations.sort();
         let duration = durations[0];
-        results.push((lib_name, duration));
+        results.push((lib, duration));
     }
     results.sort_by_key(|&(_, d)| d);
     println!("Results");
-    for (lib_name, duration) in results {
-        println!("{:10} {} ms", lib_name, duration.as_millis());
+    for (lib, duration) in results {
+        let lib_name = lib.to_possible_value().unwrap();
+        println!("{:10} {} ms", lib_name.get_name(), duration.as_millis());
     }
 }
 
-fn run_task(lib: &str, task: &str, n: u32, iter: u32) -> (String, Duration) {
+fn run_task(lib: Lib, task: Task, n: u32, iter: u32) -> (String, Duration) {
     match lib {
-        "ibig" => run_task_using::<ibig::UBig>(task, n, iter),
-        "dashu" => run_task_using::<dashu_int::UBig>(task, n, iter),
-        "num-bigint" => run_task_using::<num_bigint::BigUint>(task, n, iter),
+        Lib::IBig => run_task_using::<ibig::UBig>(task, n, iter),
+        Lib::Dashu => run_task_using::<dashu_int::UBig>(task, n, iter),
+        Lib::NumBigint => run_task_using::<num_bigint::BigUint>(task, n, iter),
         #[cfg(feature = "ramp")]
-        "ramp" => run_task_using::<ramp::Int>(task, n, iter),
-        "rug" => run_task_using::<rug::Integer>(task, n, iter),
-        "rust-gmp" => run_task_using::<gmp::mpz::Mpz>(task, n, iter),
-        "malachite" => run_task_using::<malachite_nz::natural::Natural>(task, n, iter),
-        #[cfg(feature = "ramp")]
-        _ => unreachable!(),
+        Lib::Ramp => run_task_using::<ramp::Int>(task, n, iter),
         #[cfg(not(feature = "ramp"))]
-        _ => unreachable!("ramp is only supported with nightly rust!"),
+        Lib::Ramp => unreachable!("ramp is only supported with nightly rust!"),
+        Lib::Rug => run_task_using::<rug::Integer>(task, n, iter),
+        Lib::RustGmp => run_task_using::<gmp::mpz::Mpz>(task, n, iter),
+        Lib::Malachite => run_task_using::<malachite_nz::natural::Natural>(task, n, iter),
     }
 }
 
-fn run_task_using<T: Number>(task: &str, n: u32, iter: u32) -> (String, Duration) {
+fn run_task_using<T: Number>(task: Task, n: u32, iter: u32) -> (String, Duration) {
     let mut answer = None;
     let start_time = Instant::now();
     for _ in 0..iter {
         let a = match task {
-            "e" => digits_of_e::calculate::<T>(n),
-            "fib" => fib::calculate_decimal::<T>(n),
-            "fib_hex" => fib::calculate_hex::<T>(n),
-            _ => unreachable!(),
+            Task::E => digits_of_e::calculate::<T>(n),
+            Task::Fib => fib::calculate_decimal::<T>(n),
+            Task::FibHex => fib::calculate_hex::<T>(n),
         };
         match &answer {
             None => answer = Some(a),

--- a/benchmark/src/number.rs
+++ b/benchmark/src/number.rs
@@ -79,6 +79,7 @@ impl Number for ramp::Int {
     }
 }
 
+#[cfg(feature = "gmp")]
 impl Number for rug::Integer {
     fn pow(&self, exp: u32) -> Self {
         rug::ops::Pow::pow(self, exp).into()
@@ -93,6 +94,7 @@ impl Number for rug::Integer {
     }
 }
 
+#[cfg(feature = "gmp")]
 impl Number for gmp::mpz::Mpz {
     fn pow(&self, exp: u32) -> Self {
         self.pow(exp)

--- a/integer/Cargo.toml
+++ b/integer/Cargo.toml
@@ -43,7 +43,7 @@ num-integer_v01 = { optional = true, version = "0.1.45", package = "num-integer"
 
 [dev-dependencies]
 rand_v08 = { version = "0.8.3", package = "rand" }
-criterion = { version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 serde_test = { version = "1.0.130" }
 serde_json = { version = "1.0" }
 postcard = { version = "1.0.2", features = ["alloc"] }

--- a/rational/Cargo.toml
+++ b/rational/Cargo.toml
@@ -47,7 +47,7 @@ num-traits_v02 = { optional = true, version = "0.2.15", package = "num-traits", 
 _num-modular = { optional = true, version = "0.6.1", package = "num-modular", default-features = false }
 
 [dev-dependencies]
-criterion = { version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 postcard = { version = "1.0.2", features = ["alloc"] }
 serde_test = { version = "1.0.130" }
 serde_json = { version = "1.0" }


### PR DESCRIPTION
Most significant change is in benchmark, where clap is updated to 4.4 and arguments are now define with `derive` style.