### PR TITLE
Replace unmaintained `paste` crate with `pastey`

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -27,5 +27,5 @@ dashu-ratio = { version = "0.4.1", default-features = false, path = "../rational
 
 quote = "1"
 proc-macro2 = "1"
-paste = "1.0"
+pastey = "0.2"
 rustversion = "1.0"

--- a/macros/src/parse/common.rs
+++ b/macros/src/parse/common.rs
@@ -1,5 +1,5 @@
 use dashu_base::{ParseError, Sign};
-use paste::paste;
+use pastey::paste;
 use proc_macro2::{Delimiter, Group, Literal, Punct, Spacing, TokenStream, TokenTree};
 use quote::quote;
 


### PR DESCRIPTION
## Summary

Replace the `paste` dependency with `pastey` in `dashu-macros` to address [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436).

The `paste` crate is no longer maintained and its repository has been archived. `pastey` is a maintained fork and drop-in replacement.

## Changes

- `macros/Cargo.toml`: `paste = "1.0"` → `pastey = "0.2"`
- `macros/src/parse/common.rs`: `use paste::paste` → `use pastey::paste`

## Testing

All `dashu-macros` tests pass (unit, integration, and doc-tests).