### PR TITLE
Fix IBig >> by >= bit length on DoubleWord magnitudes

### DIFF
--- a/integer/src/bits.rs
+++ b/integer/src/bits.rs
@@ -497,8 +497,13 @@ mod repr {
 
     #[inline]
     fn are_dword_low_bits_nonzero(dword: DoubleWord, n: usize) -> bool {
-        let n = n.min(WORD_BITS_USIZE) as u32;
-        dword & ones_dword(n) != 0
+        // For n >= DWORD_BITS, every bit of the dword is "low" so just test for any
+        // set bit. `ones_dword(DWORD_BITS as u32)` would underflow its shift, so we
+        // must early-return here rather than rely on it.
+        if n >= DWORD_BITS_USIZE {
+            return dword != 0;
+        }
+        dword & ones_dword(n as u32) != 0
     }
 
     fn are_slice_low_bits_nonzero(words: &[Word], n: usize) -> bool {

--- a/integer/tests/shift.rs
+++ b/integer/tests/shift.rs
@@ -201,6 +201,7 @@ fn test_ibig_shr() {
         // A negative magnitude whose highest set bit sits in the upper word
         // of a DoubleWord, shifted by an amount that equals or exceeds its
         // bit length, must round toward -infinity to -1.
+        (-(ibig!(1) << 127), 127, ibig!(-1)),
         (-(ibig!(1) << 127), 128, ibig!(-1)),
         (-(ibig!(1) << 127), 200, ibig!(-1)),
         (-(ibig!(1) << 64), 128, ibig!(-1)),

--- a/integer/tests/shift.rs
+++ b/integer/tests/shift.rs
@@ -198,6 +198,12 @@ fn test_ibig_shr() {
         ((ibig!(-0xff) << 1000) - ibig!(1), 1000, ibig!(-0x100)),
         ((ibig!(-0xff) << 1000) - (ibig!(1) << 999), 1000, ibig!(-0x100)),
         (ibig!(-0xff) << 1000, 2000, ibig!(-1)),
+        // A negative magnitude whose highest set bit sits in the upper word
+        // of a DoubleWord, shifted by an amount that equals or exceeds its
+        // bit length, must round toward -infinity to -1.
+        (-(ibig!(1) << 127), 128, ibig!(-1)),
+        (-(ibig!(1) << 127), 200, ibig!(-1)),
+        (-(ibig!(1) << 64), 128, ibig!(-1)),
     ];
     for (a, b, c) in &test_cases {
         assert_eq!(a >> b, *c);


### PR DESCRIPTION
In this case the intended behaviour seems to be that large shifts of negative numbers round towards -infinity, but instead the sign was getting lost and the integer was truncated to 0.

BTW I found this with some property-based tests using [hegel](https://hegel.dev/) doing differential testing against num-bigint (I wasn't especially looking for bugs in dashu, but I wanted to make some performance optimisations and the tests were there to make sure I didn't break anything). Happy to contribute the test suite if you're interested.