### PR TITLE
Fix IBig::to_{be,le}_bytes for negative powers of two

### DIFF
--- a/integer/src/convert.rs
+++ b/integer/src/convert.rs
@@ -184,12 +184,11 @@ impl TypedReprRef<'_> {
             self.to_le_bytes()
         };
 
-        let leading_zeros = match self {
-            RefSmall(x) => x.leading_zeros(),
-            RefLarge(words) => words.last().unwrap().leading_zeros(),
+        let needs_sign_pad = match bytes.last() {
+            None => false, // pure zero, no bytes
+            Some(&b) => (b & 0x80 != 0) != negate,
         };
-        if leading_zeros % 8 == 0 {
-            // add extra byte representing the sign, because the top bit is used
+        if needs_sign_pad {
             bytes.push(if negate { 0xff } else { 0 });
         }
 
@@ -232,12 +231,11 @@ impl TypedReprRef<'_> {
             self.to_be_bytes()
         };
 
-        let leading_zeros = match self {
-            RefSmall(x) => x.leading_zeros(),
-            RefLarge(words) => words.last().unwrap().leading_zeros(),
+        let needs_sign_pad = match bytes.first() {
+            None => false, // pure zero, no bytes
+            Some(&b) => (b & 0x80 != 0) != negate,
         };
-        if leading_zeros % 8 == 0 {
-            // add extra byte representing the sign, because the top bit is used
+        if needs_sign_pad {
             bytes.insert(0, if negate { 0xff } else { 0 });
         }
 

--- a/integer/tests/convert.rs
+++ b/integer/tests/convert.rs
@@ -49,6 +49,21 @@ fn test_from_to_be_bytes() {
 }
 
 #[test]
+fn test_be_le_bytes_roundtrip_negative_power_of_two() {
+    for v in [
+        IBig::from(i64::MIN),
+        IBig::from(i128::MIN),
+        -(IBig::ONE << 128),
+        -(IBig::ONE << 192),
+        -(IBig::ONE << 256),
+        -(IBig::ONE << 1000),
+    ] {
+        assert_eq!(IBig::from_be_bytes(&v.to_be_bytes()), v, "be round-trip for {v}");
+        assert_eq!(IBig::from_le_bytes(&v.to_le_bytes()), v, "le round-trip for {v}");
+    }
+}
+
+#[test]
 fn test_from_to_chunks() {
     let empty: [UBig; 0] = [];
     assert_eq!(*UBig::ZERO.to_chunks(1), empty);


### PR DESCRIPTION
For negative powers of two, conversion to byte formats would drop the sign. This fixes that.

(This is another bug that, like #61, I found using Hegel)