### PR TITLE
Fix force bits CI workflows and multi width bugs that this exposes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     env:
       RUST_BACKTRACE: 1
-      RUSTFLAGS: -D warnings --cfg force_bits="${{ matrix.bits }}$"
+      RUSTFLAGS: -D warnings --cfg force_bits="${{ matrix.bits }}"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/integer/src/convert.rs
+++ b/integer/src/convert.rs
@@ -1076,7 +1076,26 @@ mod repr {
         pub fn to_f64(self) -> Approximation<f64, Sign> {
             match self {
                 RefSmall(dword) => to_f64_small(dword as DoubleWord),
-                RefLarge(_) => self.to_f64_nontrivial(),
+                RefLarge(_) => {
+                    // On 16-bit Word targets a `RefLarge` value can have
+                    // `bit_len()` in [33, 64], which still fits in `u64`.
+                    // The `to_f64_nontrivial` path's shift arithmetic
+                    // assumes the value spans more than 64 bits, so route
+                    // small RefLarge values through the same direct cast
+                    // that `to_f64_small` uses.
+                    if self.bit_len() <= 64 {
+                        let v: u64 = self.try_to_unsigned().unwrap();
+                        let f = v as f64;
+                        let back = f as u64;
+                        match back.cmp(&v) {
+                            Ordering::Greater => Inexact(f, Sign::Positive),
+                            Ordering::Equal => Exact(f),
+                            Ordering::Less => Inexact(f, Sign::Negative),
+                        }
+                    } else {
+                        self.to_f64_nontrivial()
+                    }
+                }
             }
         }
 

--- a/integer/src/root_ops.rs
+++ b/integer/src/root_ops.rs
@@ -194,7 +194,13 @@ mod repr {
             // s >>= shift/2, r >>= shift
             let _ = shift::shr_in_place(&mut out, shift as u32 / 2);
             if !root_only {
-                if shift > WORD_BITS_USIZE {
+                // Use `>=` (not `>`) so the boundary case `shift == WORD_BITS_USIZE`
+                // also drops a whole word. Otherwise the `shr_in_place(shift %
+                // WORD_BITS) == shr_in_place(0)` below is a no-op and the
+                // division by 2^shift is silently skipped. Hit on 16-bit
+                // Word for inputs like `2^400 - 1` (`words.len() = 25` odd,
+                // top word fully populated, so `shift = WORD_BITS + 0`).
+                if shift >= WORD_BITS_USIZE {
                     shift::shr_in_place_one_word(&mut buffer);
                     buffer.truncate(n);
                 } else {


### PR DESCRIPTION
Turns out the CI workflow for setting force_bits had a typo in it, so it was never actually setting `force_bits` to a cfg value that was recognised, so was silently failing.

Fixing that revealed two bugs, which this PR also fixes.

This builds on https://github.com/cmpute/dashu/pull/63 (so the CI runs at all). When you decide what to do about that I'll rebase this onto whatever version of master is appropriate.