### PR TITLE
Fix extended-GCD panic when one operand divides the other

### DIFF
--- a/integer/src/gcd_ops.rs
+++ b/integer/src/gcd_ops.rs
@@ -322,25 +322,25 @@ mod repr {
         // shorter than `lhs`. The division helper requires the dividend to be
         // at least as long as the divisor, so handle that case directly instead
         // of calling it with too short a dividend.
-        let a = if locate_top_word_plus_one(residue) < lhs_len {
+        if locate_top_word_plus_one(residue) < lhs_len {
             debug_assert!(residue.iter().all(|&w| w == 0));
-            Buffer::allocate(0)
-        } else {
-            let (shift, fast_div_top) = div::normalize(lhs_clone);
-            let overflow = div::div_rem_unshifted_in_place(
-                residue,
-                lhs_clone,
-                shift,
-                fast_div_top,
-                &mut memory,
-            );
-            let mut a = Buffer::from(&residue[lhs_len..]);
-            debug_assert_eq!(residue[0], 0); // this division is an exact division
-            if overflow > 0 {
-                a.push(overflow);
-            }
-            a
-        };
+            let g = Repr::from_buffer(g);
+            let b = Repr::from_buffer(b).with_sign(b_sign);
+            return if swapped {
+                (g, b, Repr::zero())
+            } else {
+                (g, Repr::zero(), b)
+            };
+        }
+
+        let (shift, fast_div_top) = div::normalize(lhs_clone);
+        let overflow =
+            div::div_rem_unshifted_in_place(residue, lhs_clone, shift, fast_div_top, &mut memory);
+        let mut a = Buffer::from(&residue[lhs_len..]);
+        debug_assert_eq!(residue[0], 0); // this division is an exact division
+        if overflow > 0 {
+            a.push(overflow);
+        }
 
         let g = Repr::from_buffer(g);
         let a = Repr::from_buffer(a).with_sign(-b_sign);

--- a/integer/src/gcd_ops.rs
+++ b/integer/src/gcd_ops.rs
@@ -57,7 +57,7 @@ mod repr {
         cmp, div, gcd, memory,
         memory::MemoryAllocation,
         mul,
-        primitive::{shrink_dword, PrimitiveSigned},
+        primitive::{locate_top_word_plus_one, shrink_dword, PrimitiveSigned},
         repr::{
             Repr,
             TypedRepr::{self, *},
@@ -316,15 +316,31 @@ mod repr {
             }
         };
 
-        // a = residue / lhs
-        let (shift, fast_div_top) = div::normalize(lhs_clone);
-        let overflow =
-            div::div_rem_unshifted_in_place(residue, lhs_clone, shift, fast_div_top, &mut memory);
-        let mut a = Buffer::from(&residue[lhs_len..]);
-        debug_assert_eq!(residue[0], 0); // this division is an exact division
-        if overflow > 0 {
-            a.push(overflow);
-        }
+        // a = residue / lhs (an exact division)
+        //
+        // When `lhs` is a multiple of `rhs`, `a` is zero and `residue` is
+        // shorter than `lhs`. The division helper requires the dividend to be
+        // at least as long as the divisor, so handle that case directly instead
+        // of calling it with too short a dividend.
+        let a = if locate_top_word_plus_one(residue) < lhs_len {
+            debug_assert!(residue.iter().all(|&w| w == 0));
+            Buffer::allocate(0)
+        } else {
+            let (shift, fast_div_top) = div::normalize(lhs_clone);
+            let overflow = div::div_rem_unshifted_in_place(
+                residue,
+                lhs_clone,
+                shift,
+                fast_div_top,
+                &mut memory,
+            );
+            let mut a = Buffer::from(&residue[lhs_len..]);
+            debug_assert_eq!(residue[0], 0); // this division is an exact division
+            if overflow > 0 {
+                a.push(overflow);
+            }
+            a
+        };
 
         let g = Repr::from_buffer(g);
         let a = Repr::from_buffer(a).with_sign(-b_sign);

--- a/integer/src/gcd_ops.rs
+++ b/integer/src/gcd_ops.rs
@@ -326,11 +326,11 @@ mod repr {
             debug_assert!(residue.iter().all(|&w| w == 0));
             let g = Repr::from_buffer(g);
             let b = Repr::from_buffer(b).with_sign(b_sign);
-            return if swapped {
-                (g, b, Repr::zero())
+            if swapped {
+                return (g, b, Repr::zero());
             } else {
-                (g, Repr::zero(), b)
-            };
+                return (g, Repr::zero(), b);
+            }
         }
 
         let (shift, fast_div_top) = div::normalize(lhs_clone);

--- a/integer/tests/gcd.rs
+++ b/integer/tests/gcd.rs
@@ -132,6 +132,30 @@ fn test_gcd_ubig_ibig() {
 }
 
 #[test]
+fn test_gcd_ext_one_divides_the_other() {
+    // Regression: when one operand is a multiple of the other, the Bézout
+    // cofactor of the larger operand is zero, so reconstructing it as
+    // `(g - rhs*b) / lhs` divides a value with fewer words than `lhs`. For
+    // operands past the multi-word (≈5-word) threshold this tripped
+    // `assert!(lhs_len >= n)` in the divider, e.g. `gcd_ext(2^320, 2^160)`.
+    let cases = [
+        (ubig!(1) << 320, ubig!(1) << 160),
+        (ubig!(1) << 512, ubig!(1) << 64),
+        ((ubig!(1) << 320) * ubig!(3), ubig!(1) << 160),
+        (ubig!(1) << 4096, ubig!(1) << 320),
+    ];
+    for (a, b) in &cases {
+        let c = a.gcd(b);
+        let (g, x, y) = a.gcd_ext(b);
+        assert_eq!(&g, &c);
+        assert_eq!(x * a + y * b, g.into());
+        let (g, x, y) = b.gcd_ext(a);
+        assert_eq!(&g, &c);
+        assert_eq!(x * b + y * a, g.into());
+    }
+}
+
+#[test]
 #[should_panic]
 fn test_gcd_0() {
     let _ = ubig!(0).gcd(ubig!(0));


### PR DESCRIPTION
`a.gcd(b)` could panic for large `a, b` where b divides a, triggering an internal assertion about relative sizes. This adds a test for this case and fixes the bug.

AI written summary:

<details>
`gcd_ext_large` reconstructs the Bézout cofactor of the larger operand as `a = (g - rhs*b) / lhs`. When `lhs` is a multiple of `rhs`, that cofactor is zero, so the dividend `g - rhs*b` is zero and has fewer words than `lhs`. The multi-word divider requires `dividend.len() >= divisor.len()`, so for operands past the multi-word threshold this tripped `assert!(lhs_len >= n)` in `div::simple::div_rem_in_place` (in release) / a debug assertion in `div::div_rem_in_place` (in debug). For example `gcd_ext(2^320, 2^160)` panicked.

Detect the zero-cofactor case (the residue is shorter than `lhs`, hence zero by exact division) and return `a = 0` directly instead of calling the divider with too short a dividend.

Adds a regression test covering operands where one is a multiple of the other.
</details>