### PR TITLE
Inline the small-integer arithmetic and dispatch hot paths

### DIFF
--- a/integer/src/add.rs
+++ b/integer/src/add.rs
@@ -15,6 +15,7 @@ use core::cmp::Ordering::*;
 ///
 /// Returns overflow.
 #[must_use]
+#[inline]
 pub fn add_one_in_place(words: &mut [Word]) -> bool {
     for word in words {
         let (a, overflow) = word.overflowing_add(1);
@@ -30,6 +31,7 @@ pub fn add_one_in_place(words: &mut [Word]) -> bool {
 ///
 /// Returns borrow.
 #[must_use]
+#[inline]
 pub fn sub_one_in_place(words: &mut [Word]) -> bool {
     for word in words {
         let (a, borrow) = word.overflowing_sub(1);
@@ -55,6 +57,7 @@ pub fn add_word_in_place(words: &mut [Word], rhs: Word) -> bool {
 /// Add a double word to a non-empty word sequence.
 ///
 /// Returns overflow.
+#[inline]
 pub fn add_dword_in_place(words: &mut [Word], rhs: DoubleWord) -> bool {
     let (word_0, words_hi) = words.split_first_mut().unwrap();
     let (word_1, words_hi) = words_hi.split_first_mut().unwrap();
@@ -81,6 +84,7 @@ pub fn sub_word_in_place(words: &mut [Word], rhs: Word) -> bool {
 ///
 /// Returns borrow.
 #[must_use]
+#[inline]
 pub fn sub_dword_in_place(words: &mut [Word], rhs: DoubleWord) -> bool {
     let (word_0, words_hi) = words.split_first_mut().unwrap();
     let (word_1, words_hi) = words_hi.split_first_mut().unwrap();
@@ -96,6 +100,7 @@ pub fn sub_dword_in_place(words: &mut [Word], rhs: DoubleWord) -> bool {
 ///
 /// Returns overflow.
 #[must_use]
+#[inline]
 pub fn add_same_len_in_place(words: &mut [Word], rhs: &[Word]) -> bool {
     debug_assert!(words.len() == rhs.len());
 
@@ -160,6 +165,7 @@ pub fn sub_same_len_in_place_swap(lhs: &[Word], rhs: &mut [Word]) -> bool {
 
 /// (sign, lhs) = lhs - rhs
 #[must_use]
+#[inline]
 pub fn sub_in_place_with_sign(lhs: &mut [Word], rhs: &[Word]) -> Sign {
     debug_assert!(lhs.len() >= rhs.len());
     let mut lhs_len = lhs.len();

--- a/integer/src/add_ops.rs
+++ b/integer/src/add_ops.rs
@@ -79,7 +79,7 @@ pub mod repr {
 
     impl<'l, 'r> Add<TypedReprRef<'r>> for TypedReprRef<'l> {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn add(self, rhs: TypedReprRef) -> Repr {
             match (self, rhs) {
                 (RefSmall(dword0), RefSmall(dword1)) => add_dword(dword0, dword1),
@@ -98,7 +98,7 @@ pub mod repr {
 
     impl<'l> Add<TypedRepr> for TypedReprRef<'l> {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn add(self, rhs: TypedRepr) -> Repr {
             match (self, rhs) {
                 (RefSmall(dword0), Small(dword1)) => add_dword(dword0, dword1),
@@ -111,7 +111,7 @@ pub mod repr {
 
     impl<'r> Add<TypedReprRef<'r>> for TypedRepr {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn add(self, rhs: TypedReprRef) -> Repr {
             // add is commutative
             rhs.add(self)
@@ -120,7 +120,7 @@ pub mod repr {
 
     impl Add<TypedRepr> for TypedRepr {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn add(self, rhs: TypedRepr) -> Repr {
             match (self, rhs) {
                 (Small(dword0), Small(dword1)) => add_dword(dword0, dword1),
@@ -178,7 +178,7 @@ pub mod repr {
 
     impl<'l, 'r> Sub<TypedReprRef<'r>> for TypedReprRef<'l> {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn sub(self, rhs: TypedReprRef) -> Repr {
             match (self, rhs) {
                 (RefSmall(dword0), RefSmall(dword1)) => sub_dword(dword0, dword1),
@@ -191,7 +191,7 @@ pub mod repr {
 
     impl<'r> Sub<TypedReprRef<'r>> for TypedRepr {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn sub(self, rhs: TypedReprRef) -> Repr {
             match (self, rhs) {
                 (Small(dword0), RefSmall(dword1)) => sub_dword(dword0, dword1),
@@ -204,7 +204,7 @@ pub mod repr {
 
     impl<'l> Sub<TypedRepr> for TypedReprRef<'l> {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn sub(self, rhs: TypedRepr) -> Repr {
             match (self, rhs) {
                 (RefSmall(dword0), Small(dword1)) => sub_dword(dword0, dword1),
@@ -217,7 +217,7 @@ pub mod repr {
 
     impl Sub<TypedRepr> for TypedRepr {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn sub(self, rhs: TypedRepr) -> Repr {
             match (self, rhs) {
                 (Small(dword0), Small(dword1)) => sub_dword(dword0, dword1),
@@ -340,7 +340,7 @@ mod repr_signed {
 
     impl<'l, 'r> SubSigned<TypedReprRef<'r>> for TypedReprRef<'l> {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn sub_signed(self, rhs: TypedReprRef<'r>) -> Repr {
             match (self, rhs) {
                 (RefSmall(dword0), RefSmall(dword1)) => sub_dword(dword0, dword1),
@@ -361,7 +361,7 @@ mod repr_signed {
 
     impl<'l> SubSigned<TypedRepr> for TypedReprRef<'l> {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn sub_signed(self, rhs: TypedRepr) -> Self::Output {
             match (self, rhs) {
                 (RefSmall(dword0), Small(dword1)) => sub_dword(dword0, dword1),
@@ -374,7 +374,7 @@ mod repr_signed {
 
     impl<'r> SubSigned<TypedReprRef<'r>> for TypedRepr {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn sub_signed(self, rhs: TypedReprRef) -> Self::Output {
             match (self, rhs) {
                 (Small(dword0), RefSmall(dword1)) => sub_dword(dword0, dword1),
@@ -387,7 +387,7 @@ mod repr_signed {
 
     impl SubSigned<TypedRepr> for TypedRepr {
         type Output = Repr;
-        #[inline]
+        #[inline(always)]
         fn sub_signed(self, rhs: TypedRepr) -> Self::Output {
             match (self, rhs) {
                 (Small(dword0), Small(dword1)) => sub_dword(dword0, dword1),

--- a/integer/src/buffer.rs
+++ b/integer/src/buffer.rs
@@ -465,6 +465,7 @@ impl Clone for Buffer {
 }
 
 impl Drop for Buffer {
+    #[inline]
     fn drop(&mut self) {
         // SAFETY: self.ptr was allocated with self.capacity space
         unsafe {

--- a/integer/src/buffer.rs
+++ b/integer/src/buffer.rs
@@ -514,7 +514,7 @@ impl Hash for Buffer {
 }
 
 impl From<&[Word]> for Buffer {
-    #[inline]
+    #[inline(always)]
     fn from(words: &[Word]) -> Self {
         let mut buffer = Buffer::allocate(words.len());
         buffer.push_slice(words);

--- a/integer/src/buffer.rs
+++ b/integer/src/buffer.rs
@@ -123,6 +123,7 @@ impl Buffer {
     }
 
     /// Creates a `Buffer` with exactly specified capacity (in words).
+    #[inline]
     pub fn allocate_exact(capacity: usize) -> Self {
         if capacity > Self::MAX_CAPACITY {
             panic_allocate_too_much()

--- a/integer/src/helper_macros.rs
+++ b/integer/src/helper_macros.rs
@@ -140,7 +140,7 @@ macro_rules! forward_ubig_binop_to_repr {
         impl $trait<UBig> for UBig {
             type Output = UBig;
 
-            #[inline]
+            #[inline(always)]
             fn $method(self, rhs: UBig) -> UBig {
                 UBig(self.into_repr().$forward(rhs.into_repr()))
             }
@@ -149,7 +149,7 @@ macro_rules! forward_ubig_binop_to_repr {
         impl<'r> $trait<&'r UBig> for UBig {
             type Output = UBig;
 
-            #[inline]
+            #[inline(always)]
             fn $method(self, rhs: &UBig) -> UBig {
                 UBig(self.into_repr().$forward(rhs.repr()))
             }
@@ -158,7 +158,7 @@ macro_rules! forward_ubig_binop_to_repr {
         impl<'l> $trait<UBig> for &'l UBig {
             type Output = UBig;
 
-            #[inline]
+            #[inline(always)]
             fn $method(self, rhs: UBig) -> UBig {
                 UBig(self.repr().$forward(rhs.into_repr()))
             }
@@ -167,7 +167,7 @@ macro_rules! forward_ubig_binop_to_repr {
         impl<'l, 'r> $trait<&'r UBig> for &'l UBig {
             type Output = UBig;
 
-            #[inline]
+            #[inline(always)]
             fn $method(self, rhs: &UBig) -> UBig {
                 UBig(self.repr().$forward(rhs.repr()))
             }

--- a/integer/src/helper_macros.rs
+++ b/integer/src/helper_macros.rs
@@ -230,7 +230,7 @@ macro_rules! forward_ibig_binop_to_repr {
         impl $trait<IBig> for IBig {
             type $output = $ty_output;
 
-            #[inline]
+            #[inline(always)]
             fn $method(self, rhs: IBig) -> $ty_output {
                 let (sign0, mag0) = self.into_sign_repr();
                 let (sign1, mag1) = rhs.into_sign_repr();
@@ -241,7 +241,7 @@ macro_rules! forward_ibig_binop_to_repr {
         impl<'r> $trait<&'r IBig> for IBig {
             type $output = $ty_output;
 
-            #[inline]
+            #[inline(always)]
             fn $method(self, rhs: &IBig) -> $ty_output {
                 let (sign0, mag0) = self.into_sign_repr();
                 let (sign1, mag1) = rhs.as_sign_repr();
@@ -252,7 +252,7 @@ macro_rules! forward_ibig_binop_to_repr {
         impl<'l> $trait<IBig> for &'l IBig {
             type $output = $ty_output;
 
-            #[inline]
+            #[inline(always)]
             fn $method(self, rhs: IBig) -> $ty_output {
                 let (sign0, mag0) = self.as_sign_repr();
                 let (sign1, mag1) = rhs.into_sign_repr();
@@ -263,7 +263,7 @@ macro_rules! forward_ibig_binop_to_repr {
         impl<'l, 'r> $trait<&'r IBig> for &'l IBig {
             type $output = $ty_output;
 
-            #[inline]
+            #[inline(always)]
             fn $method(self, rhs: &IBig) -> $ty_output {
                 let (sign0, mag0) = self.as_sign_repr();
                 let (sign1, mag1) = rhs.as_sign_repr();

--- a/integer/src/mul_ops.rs
+++ b/integer/src/mul_ops.rs
@@ -113,7 +113,7 @@ pub(crate) mod repr {
     impl Mul<TypedRepr> for TypedRepr {
         type Output = Repr;
 
-        #[inline]
+        #[inline(always)]
         fn mul(self, rhs: TypedRepr) -> Repr {
             match (self, rhs) {
                 (Small(dword0), Small(dword1)) => mul_dword(dword0, dword1),
@@ -127,7 +127,7 @@ pub(crate) mod repr {
     impl<'l> Mul<TypedRepr> for TypedReprRef<'l> {
         type Output = Repr;
 
-        #[inline]
+        #[inline(always)]
         fn mul(self, rhs: TypedRepr) -> Repr {
             match (self, rhs) {
                 (RefSmall(dword0), Small(dword1)) => mul_dword(dword0, dword1),
@@ -141,7 +141,7 @@ pub(crate) mod repr {
     impl<'r> Mul<TypedReprRef<'r>> for TypedRepr {
         type Output = Repr;
 
-        #[inline]
+        #[inline(always)]
         fn mul(self, rhs: TypedReprRef) -> Self::Output {
             // mul is commutative
             rhs.mul(self)
@@ -151,7 +151,7 @@ pub(crate) mod repr {
     impl<'l, 'r> Mul<TypedReprRef<'r>> for TypedReprRef<'l> {
         type Output = Repr;
 
-        #[inline]
+        #[inline(always)]
         fn mul(self, rhs: TypedReprRef) -> Repr {
             match (self, rhs) {
                 (RefSmall(dword0), RefSmall(dword1)) => mul_dword(dword0, dword1),
@@ -185,6 +185,7 @@ pub(crate) mod repr {
     }
 
     /// Multiply a large number by a `DoubleWord`.
+    #[inline]
     pub(crate) fn mul_large_dword(mut buffer: Buffer, rhs: DoubleWord) -> Repr {
         match rhs {
             0 => Repr::zero(),

--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -540,6 +540,7 @@ impl Clone for Repr {
 }
 
 impl Drop for Repr {
+    #[inline]
     fn drop(&mut self) {
         let cap = self.capacity();
         if cap > 2 {

--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -223,6 +223,7 @@ impl Repr {
     }
 
     /// Get a reference to the words in the `Repr`, together with the sign.
+    #[inline]
     pub fn as_sign_slice(&self) -> (Sign, &[Word]) {
         let (capacity, sign) = self.sign_capacity();
 
@@ -571,6 +572,7 @@ impl fmt::Debug for Repr {
 }
 
 impl Hash for Repr {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         let (sign, arr) = self.as_sign_slice();
         sign.hash(state);

--- a/integer/src/shift.rs
+++ b/integer/src/shift.rs
@@ -8,6 +8,7 @@ use crate::{
 
 /// Shift left by less than WORD_BITS in place.
 /// Returns carry.
+#[inline]
 pub fn shl_in_place(words: &mut [Word], shift: u32) -> Word {
     debug_assert!(shift < WORD_BITS);
     if shift == 0 {

--- a/integer/src/shift_ops.rs
+++ b/integer/src/shift_ops.rs
@@ -282,6 +282,7 @@ pub(crate) mod repr {
     }
 
     /// Shift left large number of words by `rhs` bits.
+    #[inline]
     pub(crate) fn shl_large_ref(words: &[Word], rhs: usize) -> Repr {
         let shift_words = rhs / WORD_BITS_USIZE;
         let shift_bits = (rhs % WORD_BITS_USIZE) as u32;


### PR DESCRIPTION
Adds `#[inline]` / `#[inline(always)]` hints, primarily focused on making small-integer code paths fast.

These were tuned to be the inlines that help on https://github.com/DRMacIver/rust-bigint-benchmarks rather than hurt. In a few of the benchmarks they give a 40-50% speedup, most of the rest are more modest (5-15%. A few sub-5% improvements but I don't really trust those are real).

There is a weird slow down on a few of the benchmarks that seems to be mostly a compilation artefact (the code is sensitive to layouts). The worst of these slow-downs is ~6% in my measurements.

<details>
<summary>Benchmarking notes and before/after comparison</summary>

Measured against the merge base (current `master`) with a dashu-only run of the [rust-bigint-benchmarks](https://github.com/DRMacIver/rust-bigint-benchmarks) suite. The full sweep used reduced criterion settings for speed; every flagged change was then re-measured with default settings to separate signal from a ~±3–5% noise floor. All figures below are the default-settings (robust) re-measurements unless noted.

**Representative improvements** (negative = faster):

| Benchmark | Δ |
| --- | --- |
| `ubig_from_u64` | −48% |
| `ubig_from_u128` / `ibig_from_i64` (fast sweep) | −40% / −44% |
| `ubig_mul/10` (fast sweep) | −24% |
| `ubig_add/10` · `/100` · `/1000` | −17% · −15% · −7% |
| `ubig_clone/zero` · `/mid` | −15% · −6% |
| `ibig_clone/zero` · `/mid` | −13% · −3% |
| `ibig_drop/zero` · `/mid` | −10% · −5% |
| `ubig_eq/large` · `ubig_hash/large` | −9% · −7% |
| `ubig_sub/10` · `ubig_div/10` (fast sweep) | −10% · −14% |
| `string_round_trip`, `ubig_min/two_word`, `ubig_cmp/large` | −4% · −3% · −3% |

Across the suite ~26 dashu benchmarks improved and the rest were unchanged.

**One reproducible regression — a code-placement artifact, not a real cost:**

`ibig_clone/large` measures ~**+6%**. I bisected this and it is not an algorithmic regression:

- `IBig` and `UBig` clone through the *same* `Repr::clone`, yet the identical `ubig_clone/large` path shows no regression (~0%).
- `Repr::clone` is not modified by this PR (attributes only), and removing the only `#[inline]` on the clone allocation path (`Buffer::allocate_exact`) does **not** clear it (`ibig_clone/large` stays at +7.7%).

The crate-wide inlining shifts function placement/alignment in the binary, and the monomorphised "clone a large heap `IBig`" loop (just `malloc` + `memcpy`) lands on a less favourable cache line. It is layout/i-cache luck — reproducible per build, fragile to unrelated changes, and not removable by reverting any single inline. Small/medium clones genuinely improve because there the removed call overhead is real work saved.

</details>
