### PR TITLE
Skip redundant buffer finalisation on heap add/sub

### DIFF
--- a/integer/src/add_ops.rs
+++ b/integer/src/add_ops.rs
@@ -147,7 +147,10 @@ pub mod repr {
             buffer.push(lo);
             buffer.push(hi);
             buffer.push(1);
-            Repr::from_buffer(buffer)
+            // Top word is the freshly-pushed 1, so the buffer is already
+            // normalised. Buffer::allocate(3)'s capacity is within the
+            // max_compact bound for len=3.
+            Repr::from_buffer_normalized(buffer)
         } else {
             Repr::from_dword(res)
         }
@@ -159,7 +162,13 @@ pub mod repr {
         if add::add_dword_in_place(&mut buffer, rhs) {
             buffer.push_resizing(1);
         }
-        Repr::from_buffer(buffer)
+        // The original top word was non-zero (Repr invariant for Large) and
+        // adding into the low words can only preserve it or — if every
+        // upper word was Word::MAX and the carry chained all the way —
+        // zero it and push a fresh 1 above. Either way the new top word is
+        // non-zero. len only grows. push_resizing keeps capacity within
+        // default_capacity, which is ≤ max_compact_capacity.
+        Repr::from_buffer_normalized(buffer)
     }
 
     #[inline]
@@ -173,7 +182,14 @@ pub mod repr {
         if overflow && add::add_one_in_place(&mut buffer[n..]) {
             buffer.push_resizing(1);
         }
-        Repr::from_buffer(buffer)
+        // Callers pass `buffer` from a Large repr (len ≥ 3). Magnitude
+        // addition only ever grows the length. The final top word is either
+        // the longer operand's (already non-zero) top, a freshly-pushed
+        // carry-out 1, or — when both operands had the same length — the
+        // sum of two non-zero top words plus optional carry, which is
+        // non-zero because at least one input was non-zero.
+        debug_assert!(buffer.len() >= 3);
+        Repr::from_buffer_normalized(buffer)
     }
 
     impl<'l, 'r> Sub<TypedReprRef<'r>> for TypedReprRef<'l> {
@@ -240,7 +256,16 @@ pub mod repr {
     pub(crate) fn sub_large_dword(mut lhs: Buffer, rhs: DoubleWord) -> Repr {
         let overflow = add::sub_dword_in_place(&mut lhs, rhs);
         debug_assert!(!overflow);
-        Repr::from_buffer(lhs)
+        // After subtracting a dword from a Large buffer, the top word ends
+        // up zero only when it was exactly 1 *and* a borrow propagated all
+        // the way up to it (every intermediate word was 0). In every other
+        // case the buffer remains in canonical heap form, so we can skip
+        // the pop_zeros + shrink_to_fit pass.
+        if *lhs.last().unwrap() != 0 {
+            Repr::from_buffer_normalized(lhs)
+        } else {
+            Repr::from_buffer(lhs)
+        }
     }
 
     #[inline]
@@ -307,14 +332,22 @@ pub mod repr {
         if add::add_one_in_place(&mut buffer) {
             buffer.push_resizing(1);
         }
-        Repr::from_buffer(buffer)
+        // Same reasoning as `add_large_dword`: starting from Large (len ≥ 3,
+        // top non-zero), adding one cannot shorten the buffer and the new
+        // top word is non-zero.
+        debug_assert!(buffer.len() >= 3);
+        Repr::from_buffer_normalized(buffer)
     }
 
     #[inline]
     fn sub_large_one(mut buffer: Buffer) -> Repr {
         let overflow = add::sub_one_in_place(&mut buffer);
         debug_assert!(!overflow);
-        Repr::from_buffer(buffer)
+        if *buffer.last().unwrap() != 0 {
+            Repr::from_buffer_normalized(buffer)
+        } else {
+            Repr::from_buffer(buffer)
+        }
     }
 }
 

--- a/integer/src/add_ops.rs
+++ b/integer/src/add_ops.rs
@@ -147,9 +147,7 @@ pub mod repr {
             buffer.push(lo);
             buffer.push(hi);
             buffer.push(1);
-            // Top word is the freshly-pushed 1, so the buffer is already
-            // normalised. Buffer::allocate(3)'s capacity is within the
-            // max_compact bound for len=3.
+            // Top word is the freshly-pushed 1: already canonical (len 3).
             Repr::from_buffer_normalized(buffer)
         } else {
             Repr::from_dword(res)
@@ -162,12 +160,8 @@ pub mod repr {
         if add::add_dword_in_place(&mut buffer, rhs) {
             buffer.push_resizing(1);
         }
-        // The original top word was non-zero (Repr invariant for Large) and
-        // adding into the low words can only preserve it or — if every
-        // upper word was Word::MAX and the carry chained all the way —
-        // zero it and push a fresh 1 above. Either way the new top word is
-        // non-zero. len only grows. push_resizing keeps capacity within
-        // default_capacity, which is ≤ max_compact_capacity.
+        // Canonical: adding a dword into a Large buffer only grows len and
+        // leaves a non-zero top word.
         Repr::from_buffer_normalized(buffer)
     }
 
@@ -182,12 +176,8 @@ pub mod repr {
         if overflow && add::add_one_in_place(&mut buffer[n..]) {
             buffer.push_resizing(1);
         }
-        // Callers pass `buffer` from a Large repr (len ≥ 3). Magnitude
-        // addition only ever grows the length. The final top word is either
-        // the longer operand's (already non-zero) top, a freshly-pushed
-        // carry-out 1, or — when both operands had the same length — the
-        // sum of two non-zero top words plus optional carry, which is
-        // non-zero because at least one input was non-zero.
+        // Canonical: magnitude addition only grows len and leaves a non-zero
+        // top word.
         debug_assert!(buffer.len() >= 3);
         Repr::from_buffer_normalized(buffer)
     }
@@ -256,11 +246,8 @@ pub mod repr {
     pub(crate) fn sub_large_dword(mut lhs: Buffer, rhs: DoubleWord) -> Repr {
         let overflow = add::sub_dword_in_place(&mut lhs, rhs);
         debug_assert!(!overflow);
-        // After subtracting a dword from a Large buffer, the top word ends
-        // up zero only when it was exactly 1 *and* a borrow propagated all
-        // the way up to it (every intermediate word was 0). In every other
-        // case the buffer remains in canonical heap form, so we can skip
-        // the pop_zeros + shrink_to_fit pass.
+        // Subtracting a dword only zeroes the top word on a full borrow chain;
+        // otherwise the buffer stays canonical and skips the trim.
         if *lhs.last().unwrap() != 0 {
             Repr::from_buffer_normalized(lhs)
         } else {
@@ -332,9 +319,7 @@ pub mod repr {
         if add::add_one_in_place(&mut buffer) {
             buffer.push_resizing(1);
         }
-        // Same reasoning as `add_large_dword`: starting from Large (len ≥ 3,
-        // top non-zero), adding one cannot shorten the buffer and the new
-        // top word is non-zero.
+        // Canonical: add-one from a Large buffer keeps len and a non-zero top.
         debug_assert!(buffer.len() >= 3);
         Repr::from_buffer_normalized(buffer)
     }

--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -314,6 +314,7 @@ impl Repr {
 
     /// Create a `Repr` with a buffer allocated on heap. The leading zeros in the buffer
     /// will be trimmed and the buffer will be shrunk if there is exceeded capacity.
+    #[inline]
     pub fn from_buffer(mut buffer: Buffer) -> Self {
         buffer.pop_zeros();
 
@@ -333,6 +334,29 @@ impl Repr {
                 unsafe { mem::transmute::<Buffer, Repr>(buffer) }
             }
         }
+    }
+
+    /// Create a `Repr` from a buffer the caller asserts is already in canonical
+    /// heap form: `buffer.len() >= 3`, the top word is non-zero, and the
+    /// capacity is within `Buffer::max_compact_capacity(len)`.
+    ///
+    /// Skips the `pop_zeros` and `shrink_to_fit` work that [Repr::from_buffer]
+    /// performs. Intended for in-place arithmetic helpers where the result
+    /// shape is known from the operation: e.g. adding a small RHS into a
+    /// `Large` buffer cannot reduce `len` or zero the top word, so neither
+    /// trim is needed.
+    ///
+    /// In debug mode the preconditions are asserted; violating them in release
+    /// would leave a `Repr` whose invariants are broken.
+    #[inline]
+    pub(crate) fn from_buffer_normalized(buffer: Buffer) -> Self {
+        debug_assert!(buffer.len() >= 3);
+        debug_assert!(*buffer.last().unwrap() != 0);
+        debug_assert!(buffer.capacity() <= Buffer::max_compact_capacity(buffer.len()));
+        // SAFETY: Buffer and Repr have identical layout. The asserted
+        // preconditions match Repr's invariants for heap-resident values
+        // (capacity >= 3, top word non-zero, no excess capacity).
+        unsafe { mem::transmute(buffer) }
     }
 
     /// Create a [Repr] cloned from a reference to another [Repr]

--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -336,18 +336,11 @@ impl Repr {
         }
     }
 
-    /// Create a `Repr` from a buffer the caller asserts is already in canonical
-    /// heap form: `buffer.len() >= 3`, the top word is non-zero, and the
-    /// capacity is within `Buffer::max_compact_capacity(len)`.
-    ///
-    /// Skips the `pop_zeros` and `shrink_to_fit` work that [Repr::from_buffer]
-    /// performs. Intended for in-place arithmetic helpers where the result
-    /// shape is known from the operation: e.g. adding a small RHS into a
-    /// `Large` buffer cannot reduce `len` or zero the top word, so neither
-    /// trim is needed.
-    ///
-    /// In debug mode the preconditions are asserted; violating them in release
-    /// would leave a `Repr` whose invariants are broken.
+    /// Create a `Repr` from a buffer the caller guarantees is already in
+    /// canonical heap form (`len >= 3`, top word non-zero, capacity within
+    /// `max_compact_capacity`), skipping the `pop_zeros` / `shrink_to_fit` that
+    /// [Repr::from_buffer] does. The preconditions are debug-asserted; violating
+    /// them in release leaves a `Repr` with broken invariants.
     #[inline]
     pub(crate) fn from_buffer_normalized(buffer: Buffer) -> Self {
         debug_assert!(buffer.len() >= 3);

--- a/integer/tests/bits.rs
+++ b/integer/tests/bits.rs
@@ -372,6 +372,30 @@ fn test_not_ibig() {
 }
 
 #[test]
+fn test_not_ibig_large() {
+    // `!x == -x - 1`. With a >= 3-word magnitude this drives the heap
+    // increment/decrement helpers (`add_large_one` for positive operands,
+    // `sub_large_one` for negative ones), whose canonical-buffer fast path is
+    // otherwise unexercised by the small-value cases above.
+    let cases = [
+        ibig!(0x123456789abcdef00fedcba987654321000abcdef), // 3 words, low word != 0
+        -ibig!(0x123456789abcdef00fedcba987654321000abcdef),
+        ibig!(0xfedcba9876543210123456789abcdef0aa55cc33),
+        -ibig!(0xfedcba9876543210123456789abcdef0aa55cc33),
+        // Powers of two at a word boundary: `-1` borrows through the top word,
+        // zeroing it and shrinking the buffer (the `sub_large_one` fallback).
+        ibig!(1) << 192,
+        -(ibig!(1) << 192),
+        -(ibig!(1) << 256),
+    ];
+    for x in &cases {
+        let expected = -x - ibig!(1);
+        assert_eq!(!x.clone(), expected);
+        assert_eq!(!x, expected);
+    }
+}
+
+#[test]
 fn test_and_ibig() {
     for a in -20i8..=20i8 {
         for b in -20i8..=20i8 {


### PR DESCRIPTION
When adding heap-allocated integers, we can often skip reshaping the final buffer when the result shape is already known from the operation, which saves some time.

This is probably a bit marginal to be worth it TBH. It looked bigger in my initial benchmarking, and when I fixed the benchmarking most of the wins went away. Up to you whether you want to keep this - it's in the region of a 1% improvement on some operations, but it's quite fiddly for that small gain.

<details>
<summary>Benchmarks (layout-sampled, K=11)</summary>

Wall-clock, dashu-only, vs the merge base, measured under **11 randomised function layouts** (`ld64 -order_file`) and reported as the median — to average out the ±10% code-placement noise that otherwise swamps these small-value micro-benchmarks. The untouched `ubig_mul` control reads **0.0% ± 0.0%**, confirming a clean run.

Modest but real on the heap add/sub path it targets; inline sizes and the `mul`/`cmp` controls are unchanged.

| Benchmark | Δ |
| --- | --- |
| `ubig_sub` 1000-bit | −1.5% |
| `ubig_add` / `ubig_sub` 10000-bit | −0.6% |
| `ubig_add` 1000-bit | −1.5% (±2.2 layout) |
| `ubig_mul` (control) | 0.0% |

</details>
