### PR TITLE
Optimise Repr::clone and clone_from for the inline case

### DIFF
--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -443,6 +443,34 @@ impl Repr {
         self
     }
 
+    /// Out-of-line slow path for `Clone::clone`. Heap-resident values only
+    /// (capacity > 2 in absolute value). Kept as a separate `#[cold]` +
+    /// `#[inline(never)]` function so the inline fast path stays tiny at
+    /// every `Clone::clone` call site — without `#[inline(never)]` LLVM
+    /// chooses to inline this back into `Clone::clone`, which both bloats
+    /// the inline path and (empirically) emits noticeably slower code for
+    /// the heap case itself than going through a regular function call.
+    #[cold]
+    #[inline(never)]
+    fn clone_heap(&self) -> Self {
+        debug_assert!(self.capacity.get().unsigned_abs() > 2);
+        // SAFETY: abs(capacity) > 2 ⇒ the `heap` variant of the union is
+        // the live one.
+        unsafe {
+            let (ptr, len) = self.data.heap;
+            debug_assert!(len >= 3);
+            let mut new_buffer = Buffer::allocate(len);
+            new_buffer.push_slice(slice::from_raw_parts(ptr, len));
+            // `Buffer::allocate(len)` gives a positive capacity; preserve
+            // self's sign by negating if necessary.
+            let mut new: Repr = mem::transmute(new_buffer);
+            if self.capacity.get() < 0 {
+                new.capacity = NonZeroIsize::new_unchecked(-new.capacity.get());
+            }
+            new
+        }
+    }
+
     /// Returns a number representing sign of self.
     ///
     /// * [Self::zero] if the number is zero
@@ -461,33 +489,28 @@ impl Repr {
 
 // Cloning for Repr is written in a verbose way because it's performance critical.
 impl Clone for Repr {
+    #[inline]
     fn clone(&self) -> Self {
-        let (capacity, sign) = self.sign_capacity();
-
-        // SAFETY: see the comments inside the block
-        let new = unsafe {
-            // inline the data if the length is less than 3
-            // SAFETY: we check the capacity before accessing the variants
-            if capacity <= 2 {
-                Repr {
-                    data: ReprData {
-                        inline: self.data.inline,
-                    },
-                    // SAFETY: the capacity is from self, which guarantees it to be zero
-                    capacity: NonZeroIsize::new_unchecked(capacity as isize),
-                }
-            } else {
-                let (ptr, len) = self.data.heap;
-                // SAFETY: len is at least 2 when it's heap allocated (invariant of Repr)
-                let mut new_buffer = Buffer::allocate(len);
-                new_buffer.push_slice(slice::from_raw_parts(ptr, len));
-
-                // SAFETY: abs(self.capacity) >= 3 => self.data.len >= 3
-                // so the capacity and len of new_buffer will be both >= 3
-                mem::transmute::<Buffer, Repr>(new_buffer)
-            }
-        };
-        new.with_sign(sign)
+        // Inline case (abs(capacity) <= 2): just copy the union and the
+        // signed capacity verbatim. Avoids the `sign_capacity` extract +
+        // `with_sign` re-apply round-trip the old implementation did.
+        //
+        // Profiled hegel-rust shrinker workloads spend ~13 % of total Ir
+        // in this function, almost entirely on the inline case (values
+        // are i64- or i128-sized). Inlining the trivial path here lets
+        // it disappear into the caller; the heavier heap path is split
+        // out into a `#[cold]` helper.
+        if self.capacity.get().unsigned_abs() <= 2 {
+            return Repr {
+                data: ReprData {
+                    // SAFETY: capacity in {-2,-1,1,2} ⇒ the `inline`
+                    // variant of the union is the live one.
+                    inline: unsafe { self.data.inline },
+                },
+                capacity: self.capacity,
+            };
+        }
+        self.clone_heap()
     }
 
     fn clone_from(&mut self, src: &Self) {

--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -513,14 +513,19 @@ impl Clone for Repr {
         self.clone_heap()
     }
 
+    #[inline]
     fn clone_from(&mut self, src: &Self) {
-        let (src_cap, src_sign) = src.sign_capacity();
-        let (cap, _) = self.sign_capacity();
+        let src_cap_raw = src.capacity.get();
+        let cap = self.capacity.get().unsigned_abs();
 
         // SAFETY: see the comments inside the block
         unsafe {
-            // shortcut for inlined data
-            if src_cap <= 2 {
+            // Fast path: src is inline. Same shape as `clone`'s fast path
+            // — copy union + signed capacity, with a rare dealloc when
+            // self was previously heap-resident. The shrinker's
+            // ChoiceNode = (IBig, IBig, IBig, IBig) clone pattern is
+            // dominated by inline-source clones.
+            if src_cap_raw.unsigned_abs() <= 2 {
                 if cap > 2 {
                     // release the old buffer if necessary
                     // SAFETY: self.data.heap.0 must be valid pointer if cap > 2
@@ -530,6 +535,7 @@ impl Clone for Repr {
                 self.capacity = src.capacity;
                 return;
             }
+            let src_sign = if src_cap_raw > 0 { Sign::Positive } else { Sign::Negative };
 
             // SAFETY: we checked that abs(src.capacity) > 2
             let (src_ptr, src_len) = src.data.heap;

--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -486,7 +486,7 @@ impl Repr {
             // and the bound check inside `Buffer::allocate_raw` would
             // never fire.
             let new_cap = len + len / 8 + 2;
-            debug_assert!(new_cap >= 3 && new_cap <= Buffer::MAX_CAPACITY);
+            debug_assert!((3..=Buffer::MAX_CAPACITY).contains(&new_cap));
 
             let layout = core::alloc::Layout::from_size_align_unchecked(
                 new_cap * mem::size_of::<Word>(),
@@ -579,7 +579,11 @@ impl Clone for Repr {
                 self.capacity = src.capacity;
                 return;
             }
-            let src_sign = if src_cap_raw > 0 { Sign::Positive } else { Sign::Negative };
+            let src_sign = if src_cap_raw > 0 {
+                Sign::Positive
+            } else {
+                Sign::Negative
+            };
 
             // SAFETY: we checked that abs(src.capacity) > 2
             let (src_ptr, src_len) = src.data.heap;

--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -443,31 +443,75 @@ impl Repr {
         self
     }
 
-    /// Out-of-line slow path for `Clone::clone`. Heap-resident values only
-    /// (capacity > 2 in absolute value). Kept as a separate `#[cold]` +
-    /// `#[inline(never)]` function so the inline fast path stays tiny at
-    /// every `Clone::clone` call site — without `#[inline(never)]` LLVM
-    /// chooses to inline this back into `Clone::clone`, which both bloats
-    /// the inline path and (empirically) emits noticeably slower code for
-    /// the heap case itself than going through a regular function call.
-    #[cold]
+    /// Slow path for `Clone::clone`. Heap-resident values only
+    /// (capacity > 2 in absolute value).
+    ///
+    /// Allocates directly via `alloc::alloc::alloc` rather than going
+    /// through `Buffer::allocate` + `push_slice` + `mem::transmute`.
+    /// That bypass saves:
+    ///
+    /// * the redundant `0 < capacity <= MAX_CAPACITY` assertion inside
+    ///   `Buffer::allocate_raw` (we just computed `new_cap` from a
+    ///   bounded `len`);
+    /// * `push_slice`'s `len <= capacity - 0` check (we own the buffer
+    ///   we just allocated, the only `len` ever written is the input
+    ///   `len`);
+    /// * `Buffer::allocate_exact`'s second check on the same bound;
+    /// * the `mem::transmute(Buffer) -> Repr` shape and the conditional
+    ///   sign-flip dance — the signed capacity is set directly.
+    ///
+    /// `#[inline(never)]` (without `#[cold]`) keeps the inline fast path
+    /// tiny at every `Clone::clone` instantiation and gives LLVM a stable
+    /// call boundary so the inline path's code-layout doesn't depend on
+    /// how aggressively the heap path gets considered for inlining.
+    ///
+    /// Removing the attribute lets LLVM occasionally inline this back —
+    /// which leaves the inline microbench unchanged but regresses
+    /// `ibig_clone/large` by ~5 pp (probably i-cache: the inlined
+    /// 30-instruction heap body lands inside the bench's hot loop).
+    /// `#[cold]` was also dropped (`shrinker_consider` gains ~3 pp without
+    /// it; see commit notes).
     #[inline(never)]
     fn clone_heap(&self) -> Self {
         debug_assert!(self.capacity.get().unsigned_abs() > 2);
-        // SAFETY: abs(capacity) > 2 ⇒ the `heap` variant of the union is
-        // the live one.
+        // SAFETY: abs(capacity) > 2 ⇒ the `heap` variant of the union
+        // is the live one, and `len >= 3`.
         unsafe {
-            let (ptr, len) = self.data.heap;
+            let (src_ptr, len) = self.data.heap;
             debug_assert!(len >= 3);
-            let mut new_buffer = Buffer::allocate(len);
-            new_buffer.push_slice(slice::from_raw_parts(ptr, len));
-            // `Buffer::allocate(len)` gives a positive capacity; preserve
-            // self's sign by negating if necessary.
-            let mut new: Repr = mem::transmute(new_buffer);
-            if self.capacity.get() < 0 {
-                new.capacity = NonZeroIsize::new_unchecked(-new.capacity.get());
+
+            // Mirrors `Buffer::default_capacity(len)`. `len <=
+            // Buffer::MAX_CAPACITY` is invariant for any heap Repr, and
+            // `default_capacity` is monotone, so `new_cap` is bounded
+            // and the bound check inside `Buffer::allocate_raw` would
+            // never fire.
+            let new_cap = len + len / 8 + 2;
+            debug_assert!(new_cap >= 3 && new_cap <= Buffer::MAX_CAPACITY);
+
+            let layout = core::alloc::Layout::from_size_align_unchecked(
+                new_cap * mem::size_of::<Word>(),
+                mem::align_of::<Word>(),
+            );
+            let new_ptr = alloc::alloc::alloc(layout) as *mut Word;
+            if new_ptr.is_null() {
+                crate::error::panic_out_of_memory();
             }
-            new
+
+            ptr::copy_nonoverlapping(src_ptr, new_ptr, len);
+
+            // Set the result's signed capacity in one shot so we never
+            // build a positive Repr only to negate it back.
+            let signed_cap = if self.capacity.get() < 0 {
+                -(new_cap as isize)
+            } else {
+                new_cap as isize
+            };
+            Repr {
+                data: ReprData {
+                    heap: (new_ptr, len),
+                },
+                capacity: NonZeroIsize::new_unchecked(signed_cap),
+            }
         }
     }
 

--- a/integer/src/repr.rs
+++ b/integer/src/repr.rs
@@ -443,34 +443,12 @@ impl Repr {
         self
     }
 
-    /// Slow path for `Clone::clone`. Heap-resident values only
-    /// (capacity > 2 in absolute value).
+    /// Slow path for `Clone::clone`: heap-resident values only (|capacity| > 2).
     ///
-    /// Allocates directly via `alloc::alloc::alloc` rather than going
-    /// through `Buffer::allocate` + `push_slice` + `mem::transmute`.
-    /// That bypass saves:
-    ///
-    /// * the redundant `0 < capacity <= MAX_CAPACITY` assertion inside
-    ///   `Buffer::allocate_raw` (we just computed `new_cap` from a
-    ///   bounded `len`);
-    /// * `push_slice`'s `len <= capacity - 0` check (we own the buffer
-    ///   we just allocated, the only `len` ever written is the input
-    ///   `len`);
-    /// * `Buffer::allocate_exact`'s second check on the same bound;
-    /// * the `mem::transmute(Buffer) -> Repr` shape and the conditional
-    ///   sign-flip dance — the signed capacity is set directly.
-    ///
-    /// `#[inline(never)]` (without `#[cold]`) keeps the inline fast path
-    /// tiny at every `Clone::clone` instantiation and gives LLVM a stable
-    /// call boundary so the inline path's code-layout doesn't depend on
-    /// how aggressively the heap path gets considered for inlining.
-    ///
-    /// Removing the attribute lets LLVM occasionally inline this back —
-    /// which leaves the inline microbench unchanged but regresses
-    /// `ibig_clone/large` by ~5 pp (probably i-cache: the inlined
-    /// 30-instruction heap body lands inside the bench's hot loop).
-    /// `#[cold]` was also dropped (`shrinker_consider` gains ~3 pp without
-    /// it; see commit notes).
+    /// Allocates directly instead of going through `Buffer::allocate` +
+    /// `push_slice` + `mem::transmute`, skipping the redundant capacity/length
+    /// bound checks and the sign-flip dance. Kept `#[inline(never)]` so the
+    /// inline fast path in `clone` stays small.
     #[inline(never)]
     fn clone_heap(&self) -> Self {
         debug_assert!(self.capacity.get().unsigned_abs() > 2);
@@ -535,15 +513,9 @@ impl Repr {
 impl Clone for Repr {
     #[inline]
     fn clone(&self) -> Self {
-        // Inline case (abs(capacity) <= 2): just copy the union and the
-        // signed capacity verbatim. Avoids the `sign_capacity` extract +
-        // `with_sign` re-apply round-trip the old implementation did.
-        //
-        // Profiled hegel-rust shrinker workloads spend ~13 % of total Ir
-        // in this function, almost entirely on the inline case (values
-        // are i64- or i128-sized). Inlining the trivial path here lets
-        // it disappear into the caller; the heavier heap path is split
-        // out into a `#[cold]` helper.
+        // Inline case (|capacity| <= 2): copy the union and signed capacity
+        // verbatim, avoiding the `sign_capacity` + `with_sign` round-trip the
+        // old implementation did. The heap path is split into `clone_heap`.
         if self.capacity.get().unsigned_abs() <= 2 {
             return Repr {
                 data: ReprData {
@@ -564,11 +536,8 @@ impl Clone for Repr {
 
         // SAFETY: see the comments inside the block
         unsafe {
-            // Fast path: src is inline. Same shape as `clone`'s fast path
-            // — copy union + signed capacity, with a rare dealloc when
-            // self was previously heap-resident. The shrinker's
-            // ChoiceNode = (IBig, IBig, IBig, IBig) clone pattern is
-            // dominated by inline-source clones.
+            // Fast path: src is inline. Copy union + signed capacity, with a
+            // rare dealloc when self was previously heap-resident.
             if src_cap_raw.unsigned_abs() <= 2 {
                 if cap > 2 {
                     // release the old buffer if necessary

--- a/integer/tests/clone.rs
+++ b/integer/tests/clone.rs
@@ -1,0 +1,53 @@
+mod helper_macros;
+
+#[test]
+fn test_clone_inline_and_heap() {
+    // value (and sign) preserved across clone, for inline and heap reprs
+    let ubigs = [
+        ubig!(0),
+        ubig!(5),
+        ubig!(0x10000000000000000),   // 2^64, two-word inline
+        ubig!(1) << 200,              // heap
+        (ubig!(1) << 256) - ubig!(1), // heap, all ones
+    ];
+    for v in &ubigs {
+        assert_eq!(&v.clone(), v);
+    }
+    let ibigs = [
+        ibig!(0),
+        ibig!(5),
+        ibig!(-5),
+        ibig!(1) << 200,
+        -(ibig!(1) << 200),
+    ];
+    for v in &ibigs {
+        assert_eq!(&v.clone(), v);
+    }
+}
+
+#[test]
+fn test_clone_from_transitions() {
+    // clone_from across every inline/heap combination of (dst, src) — including
+    // dst heap-allocated with an inline src (dst's buffer must be freed) and
+    // inline dst with a heap src (must allocate).
+    let vals = [
+        ubig!(0),
+        ubig!(7),
+        ubig!(0x10000000000000000), // inline cap 2
+        ubig!(1) << 130,            // heap
+        ubig!(1) << 200,            // heap, larger
+    ];
+    for src in &vals {
+        for dst0 in &vals {
+            let mut dst = dst0.clone();
+            dst.clone_from(src);
+            assert_eq!(&dst, src, "clone_from {dst0} <- {src}");
+        }
+    }
+    // signed: heap negative -> inline negative -> heap positive
+    let mut x = -(ibig!(1) << 200);
+    x.clone_from(&ibig!(-3));
+    assert_eq!(x, ibig!(-3));
+    x.clone_from(&(ibig!(1) << 200));
+    assert_eq!(x, ibig!(1) << 200);
+}


### PR DESCRIPTION
Optimises clones for inline-sized values by copying the union and signed capacity directly, with the heap path split into a separate `clone_heap` helper; `clone_from` gets the matching fast path. About a 20% improvement in one of my benchmarks (clone followed by drop, heavily hitting the inline path).

<details>
<summary>Benchmarks (layout-sampled, K=11)</summary>

Wall-clock, dashu-only, vs the merge base, measured under **11 randomised function layouts** (`ld64 -order_file`) and reported as the median — to average out the ±10% code-placement noise that otherwise swamps these small-value micro-benchmarks. The untouched `ubig_mul` control reads **0.0% ± 0.0%**, confirming a clean run.

Inline-value clone is faster; heap clone is unchanged. (`ibig_drop` clones-then-drops each iteration, so it reflects the inline clone speed-up.)

| Benchmark | Δ |
| --- | --- |
| `ibig_drop` inline (clone+drop) | −20% |
| `ubig_clone` / `ibig_clone` inline | ~−5% |
| `*_clone` / `*_drop` heap (large/mid) | unchanged |
| `ubig_mul` (control) | 0.0% |

</details>
