### PR TITLE
Use word instead of bool for add/sub carry chain

### DIFF
--- a/integer/CHANGELOG.md
+++ b/integer/CHANGELOG.md
@@ -6,6 +6,9 @@
 - `UBig::from_u64` and `IBig::from_i64`, const on 32-bit and 64-bit targets.
 
 ### Improve
+- Addition and subtraction carry/borrow propagation now uses `Word` (u64/u32) instead of `bool` throughout the architecture-specific `add_with_carry` and `sub_with_borrow` functions, eliminating `bool`↔Word conversions in the inner loops. Combined with comparison-based overflow detection on the generic code path, this reduces the per-word instruction count from ~9 to ~7 on ARM64. ~36% faster addition and ~17% faster subtraction at 10000-bit operand sizes, bringing dashu roughly even with malachite at this scale. Added `#[inline]` annotations on the hot loop functions to ensure cross-function optimization.
+
+### Improve
 - Logarithm for very large values uses power-sequence decomposition, replacing iterative single-step multiplication.
 - Improve power-of-two base formatting ([#3](https://github.com/cmpute/dashu/pull/3))
 

--- a/integer/src/add.rs
+++ b/integer/src/add.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     arch::{
-        self,
         add::{add_with_carry, sub_with_borrow},
         word::{DoubleWord, SignedWord, Word},
     },
@@ -61,9 +60,9 @@ pub fn add_dword_in_place(words: &mut [Word], rhs: DoubleWord) -> bool {
     let (b0, b1) = split_dword(rhs);
     let (s0, carry) = word_0.overflowing_add(b0);
     *word_0 = s0;
-    let (s1, carry) = add_with_carry(*word_1, b1, carry);
+    let (s1, carry) = add_with_carry(*word_1, b1, Word::from(carry));
     *word_1 = s1;
-    carry && add_one_in_place(words_hi)
+    carry != 0 && add_one_in_place(words_hi)
 }
 
 /// Subtract a word from a non-empty word sequence.
@@ -87,46 +86,49 @@ pub fn sub_dword_in_place(words: &mut [Word], rhs: DoubleWord) -> bool {
     let (b0, b1) = split_dword(rhs);
     let (s0, borrow) = word_0.overflowing_sub(b0);
     *word_0 = s0;
-    let (s1, borrow) = sub_with_borrow(*word_1, b1, borrow);
+    let (s1, borrow) = sub_with_borrow(*word_1, b1, Word::from(borrow));
     *word_1 = s1;
-    borrow && sub_one_in_place(words_hi)
+    borrow != 0 && sub_one_in_place(words_hi)
 }
 
 /// Add a word sequence of same length in place.
 ///
 /// Returns overflow.
 #[must_use]
+#[inline]
 pub fn add_same_len_in_place(words: &mut [Word], rhs: &[Word]) -> bool {
     debug_assert!(words.len() == rhs.len());
 
-    let mut carry = false;
+    let mut carry: Word = 0;
     for (a, b) in words.iter_mut().zip(rhs.iter()) {
-        let (sum, c) = arch::add::add_with_carry(*a, *b, carry);
+        let (sum, c) = add_with_carry(*a, *b, carry);
         *a = sum;
         carry = c;
     }
-    carry
+    carry != 0
 }
 
 /// lhs -= rhs
 ///
 /// Returns borrow.
 #[must_use]
+#[inline]
 pub fn sub_same_len_in_place(lhs: &mut [Word], rhs: &[Word]) -> bool {
     debug_assert!(lhs.len() == rhs.len());
-    let mut borrow = false;
+    let mut borrow: Word = 0;
     for (a, b) in lhs.iter_mut().zip(rhs.iter()) {
-        let (diff, borrow1) = arch::add::sub_with_borrow(*a, *b, borrow);
+        let (diff, borrow1) = sub_with_borrow(*a, *b, borrow);
         *a = diff;
         borrow = borrow1;
     }
-    borrow
+    borrow != 0
 }
 
 /// lhs += rhs
 ///
 /// Returns overflow.
 #[must_use]
+#[inline]
 pub fn add_in_place(lhs: &mut [Word], rhs: &[Word]) -> bool {
     let (lhs_lo, lhs_hi) = lhs.split_at_mut(rhs.len());
     let carry = add_same_len_in_place(lhs_lo, rhs);
@@ -137,6 +139,7 @@ pub fn add_in_place(lhs: &mut [Word], rhs: &[Word]) -> bool {
 ///
 /// Returns borrow.
 #[must_use]
+#[inline]
 pub fn sub_in_place(lhs: &mut [Word], rhs: &[Word]) -> bool {
     let (lhs_lo, lhs_hi) = lhs.split_at_mut(rhs.len());
     let borrow = sub_same_len_in_place(lhs_lo, rhs);
@@ -147,15 +150,16 @@ pub fn sub_in_place(lhs: &mut [Word], rhs: &[Word]) -> bool {
 ///
 /// Returns borrow.
 #[must_use]
+#[inline]
 pub fn sub_same_len_in_place_swap(lhs: &[Word], rhs: &mut [Word]) -> bool {
     debug_assert!(lhs.len() == rhs.len());
-    let mut borrow = false;
+    let mut borrow: Word = 0;
     for (a, b) in lhs.iter().zip(rhs.iter_mut()) {
-        let (diff, borrow1) = arch::add::sub_with_borrow(*a, *b, borrow);
+        let (diff, borrow1) = sub_with_borrow(*a, *b, borrow);
         *b = diff;
         borrow = borrow1;
     }
-    borrow
+    borrow != 0
 }
 
 /// (sign, lhs) = lhs - rhs

--- a/integer/src/arch/generic/add.rs
+++ b/integer/src/arch/generic/add.rs
@@ -4,18 +4,20 @@ use crate::arch::word::Word;
 ///
 /// Returns (result, overflow).
 #[inline]
-pub fn add_with_carry(a: Word, b: Word, carry: bool) -> (Word, bool) {
-    let (sum, c0) = a.overflowing_add(b);
-    let (sum, c1) = sum.overflowing_add(Word::from(carry));
-    (sum, c0 | c1)
+pub fn add_with_carry(a: Word, b: Word, carry: Word) -> (Word, Word) {
+    let sum_nc = a.wrapping_add(b);
+    let sum = sum_nc.wrapping_add(carry);
+    let carry_out = Word::from(sum_nc < a) | Word::from(sum < sum_nc);
+    (sum, carry_out)
 }
 
 /// Subtract a - b - borrow.
 ///
 /// Returns (result, overflow).
 #[inline]
-pub fn sub_with_borrow(a: Word, b: Word, borrow: bool) -> (Word, bool) {
-    let (diff, b0) = a.overflowing_sub(b);
-    let (diff, b1) = diff.overflowing_sub(Word::from(borrow));
-    (diff, b0 | b1)
+pub fn sub_with_borrow(a: Word, b: Word, borrow: Word) -> (Word, Word) {
+    let diff_nb = a.wrapping_sub(b);
+    let diff = diff_nb.wrapping_sub(borrow);
+    let borrow_out = Word::from(diff_nb > a) | Word::from(diff > diff_nb);
+    (diff, borrow_out)
 }

--- a/integer/src/arch/x86/add.rs
+++ b/integer/src/arch/x86/add.rs
@@ -9,12 +9,12 @@ use crate::arch::word::Word;
 // compiles; `unused_unsafe` is allowed so post-1.81 builds don't warn.
 #[inline]
 #[allow(unused_unsafe)]
-pub fn add_with_carry(a: Word, b: Word, carry: bool) -> (Word, bool) {
+pub fn add_with_carry(a: Word, b: Word, carry: Word) -> (Word, Word) {
     let mut sum = 0;
     // SAFETY: this intrinsic is actually safe; the `unsafe` block is
     // retained for MSRV 1.68 where the intrinsic was still `unsafe fn`.
-    let carry = unsafe { core::arch::x86::_addcarry_u32(carry.into(), a, b, &mut sum) };
-    (sum, carry != 0)
+    let carry = unsafe { core::arch::x86::_addcarry_u32((carry & 1) as u8, a, b, &mut sum) };
+    (sum, Word::from(carry))
 }
 
 /// Subtract a - b - borrow.
@@ -22,9 +22,9 @@ pub fn add_with_carry(a: Word, b: Word, carry: bool) -> (Word, bool) {
 /// Returns (result, overflow).
 #[inline]
 #[allow(unused_unsafe)]
-pub fn sub_with_borrow(a: Word, b: Word, borrow: bool) -> (Word, bool) {
+pub fn sub_with_borrow(a: Word, b: Word, borrow: Word) -> (Word, Word) {
     let mut diff = 0;
     // SAFETY: see `add_with_carry`.
-    let borrow = unsafe { core::arch::x86::_subborrow_u32(borrow.into(), a, b, &mut diff) };
-    (diff, borrow != 0)
+    let borrow = unsafe { core::arch::x86::_subborrow_u32((borrow & 1) as u8, a, b, &mut diff) };
+    (diff, Word::from(borrow))
 }

--- a/integer/src/arch/x86_64/add.rs
+++ b/integer/src/arch/x86_64/add.rs
@@ -9,12 +9,12 @@ use crate::arch::word::Word;
 // compiles; `unused_unsafe` is allowed so post-1.81 builds don't warn.
 #[inline]
 #[allow(unused_unsafe)]
-pub fn add_with_carry(a: Word, b: Word, carry: bool) -> (Word, bool) {
+pub fn add_with_carry(a: Word, b: Word, carry: Word) -> (Word, Word) {
     let mut sum = 0;
     // SAFETY: this intrinsic is actually safe; the `unsafe` block is
     // retained for MSRV 1.68 where the intrinsic was still `unsafe fn`.
-    let carry = unsafe { core::arch::x86_64::_addcarry_u64(carry.into(), a, b, &mut sum) };
-    (sum, carry != 0)
+    let carry = unsafe { core::arch::x86_64::_addcarry_u64((carry & 1) as u8, a, b, &mut sum) };
+    (sum, Word::from(carry))
 }
 
 /// Subtract a - b - borrow.
@@ -22,9 +22,9 @@ pub fn add_with_carry(a: Word, b: Word, carry: bool) -> (Word, bool) {
 /// Returns (result, overflow).
 #[inline]
 #[allow(unused_unsafe)]
-pub fn sub_with_borrow(a: Word, b: Word, borrow: bool) -> (Word, bool) {
+pub fn sub_with_borrow(a: Word, b: Word, borrow: Word) -> (Word, Word) {
     let mut diff = 0;
     // SAFETY: see `add_with_carry`.
-    let borrow = unsafe { core::arch::x86_64::_subborrow_u64(borrow.into(), a, b, &mut diff) };
-    (diff, borrow != 0)
+    let borrow = unsafe { core::arch::x86_64::_subborrow_u64((borrow & 1) as u8, a, b, &mut diff) };
+    (diff, Word::from(borrow))
 }

--- a/integer/src/mul/simple.rs
+++ b/integer/src/mul/simple.rs
@@ -87,14 +87,14 @@ fn add_signed_mul_chunk(
 fn add_mul_chunk(c: &mut [Word], a: &[Word], b: &[Word]) -> bool {
     debug_assert!(a.len() >= b.len() && c.len() == a.len() + b.len());
     debug_assert!(a.len() < 2 * CHUNK_LEN);
-    let mut carry = false;
+    let mut carry: Word = 0;
     for (i, m) in b.iter().enumerate() {
         let carry_word = mul::add_mul_word_same_len_in_place(&mut c[i..i + a.len()], *m, a);
         let (carry_word, carry_next) = arch::add::add_with_carry(c[i + a.len()], carry_word, carry);
         c[i + a.len()] = carry_word;
         carry = carry_next;
     }
-    carry
+    carry != 0
 }
 
 /// c -= a * b
@@ -104,7 +104,7 @@ fn add_mul_chunk(c: &mut [Word], a: &[Word], b: &[Word]) -> bool {
 fn sub_mul_chunk(c: &mut [Word], a: &[Word], b: &[Word]) -> bool {
     debug_assert!(a.len() >= b.len() && c.len() == a.len() + b.len());
     debug_assert!(a.len() < 2 * CHUNK_LEN);
-    let mut borrow = false;
+    let mut borrow: Word = 0;
     for (i, m) in b.iter().enumerate() {
         let borrow_word = mul::sub_mul_word_same_len_in_place(&mut c[i..i + a.len()], *m, a);
         let (borrow_word, borrow_next) =
@@ -112,5 +112,5 @@ fn sub_mul_chunk(c: &mut [Word], a: &[Word], b: &[Word]) -> bool {
         c[i + a.len()] = borrow_word;
         borrow = borrow_next;
     }
-    borrow
+    borrow != 0
 }

--- a/integer/src/sqr/simple.rs
+++ b/integer/src/sqr/simple.rs
@@ -30,7 +30,7 @@ pub fn square(b: &mut [Word], a: &[Word]) {
      */
 
     // first step (triangular part)
-    let mut c0 = false;
+    let mut c0: Word = 0;
     let mut offset = 1;
     let mut a_cur = a;
     while let Some((m, new_cur)) = a_cur.split_first() {
@@ -65,5 +65,5 @@ pub fn square(b: &mut [Word], a: &[Word]) {
     }
 
     // aggregate carry bits
-    *b.last_mut().unwrap() += c0 as Word + c1 as Word + c2 as Word;
+    *b.last_mut().unwrap() += c0 + c1 as Word + c2 as Word;
 }


### PR DESCRIPTION
 Summary

  Change the carry/borrow type in all architecture-specific add_with_carry and sub_with_borrow functions from bool to Word, and use comparison-based overflow detection on the generic
  code path. This eliminates bool↔Word conversions in the inner loops and reduces the per-word instruction count from ~9 to ~7 on ARM64.

  Changes

  7 files, +49/−40 lines

  Arch functions (integer/src/arch/{generic,x86,x86_64}/add.rs)

  - add_with_carry(a: Word, b: Word, carry: bool) -> (Word, bool) → (Word, Word, Word) -> (Word, Word)
  - sub_with_borrow(a: Word, b: Word, borrow: bool) -> (Word, bool) → (Word, Word, Word) -> (Word, Word)
  - Generic path: switched from overflowing_add/overflowing_sub to wrapping_add/wrapping_sub with comparison-based overflow detection (sum < a). This generates better ARM64 code
  (ADDS+CSET+ADDS+CSINC instead of ADDS+CSET+ORR).
  - x86/x86_64 paths: adapted intrinsic calls with (carry & 1) as u8 on input and Word::from(carry) on output.

  Hot loops (integer/src/add.rs)

  - add_same_len_in_place, sub_same_len_in_place, sub_same_len_in_place_swap: carry/borrow loop variable changed from bool to Word, return carry != 0.
  - Added #[inline] on all five hot functions to ensure the comparison-based arithmetic inlines through the call chain.
  - add_dword_in_place / sub_dword_in_place: convert bool carry from overflowing_add to Word via Word::from().

  Callers (integer/src/{mul,sqr}/simple.rs)

  - add_mul_chunk / sub_mul_chunk / squaring: carry/borrow variables changed from bool to Word.

  Benchmarks (Apple M-series, non-throttled)

  ubig_add
```
  ┌───────┬──────────┬──────────┬────────┐
  │ size  │  master  │ this PR  │ change │
  ├───────┼──────────┼──────────┼────────┤
  │ 100   │ 1.64 ns  │ 1.64 ns  │ —      │
  ├───────┼──────────┼──────────┼────────┤
  │ 1000  │ 31.9 ns  │ 31.6 ns  │ —      │
  ├───────┼──────────┼──────────┼────────┤
  │ 10000 │ 220.5 ns │ 138.7 ns │ −37%   │
  └───────┴──────────┴──────────┴────────┘
```
  At 10000-bit, dashu now beats malachite (140.5 ns).

  ubig_sub
```
  ┌───────┬──────────┬──────────┬────────┐
  │ size  │  master  │ this PR  │ change │
  ├───────┼──────────┼──────────┼────────┤
  │ 100   │ 1.69 ns  │ 1.67 ns  │ —      │
  ├───────┼──────────┼──────────┼────────┤
  │ 1000  │ 30.5 ns  │ 29.8 ns  │ —      │
  ├───────┼──────────┼──────────┼────────┤
  │ 10000 │ 176.3 ns │ 144.2 ns │ −18%   │
  └───────┴──────────┴──────────┴────────┘
```
  ubig_mul
```
  ┌─────────┬──────────┬──────────┬────────┐
  │  size   │  master  │ this PR  │ change │
  ├─────────┼──────────┼──────────┼────────┤
  │ 100     │ 20.0 ns  │ 18.7 ns  │ −7%    │
  ├─────────┼──────────┼──────────┼────────┤
  │ 1000    │ 245.8 ns │ 249.9 ns │ —      │
  ├─────────┼──────────┼──────────┼────────┤
  │ 10000   │ 12.61 µs │ 11.74 µs │ −7%    │
  ├─────────┼──────────┼──────────┼────────┤
  │ 100000  │ 451.9 µs │ 412.2 µs │ −9%    │
  ├─────────┼──────────┼──────────┼────────┤
  │ 1000000 │ 14.83 ms │ 12.08 ms │ −19%   │
  └─────────┴──────────┴──────────┴────────┘
```
  At 100/1000 bits the values are inlined (1–2 words, or ~16 words where dispatch overhead dominates the inner loop), so the carry-chain change has negligible effect. The benefit
  grows with operand size as the inner loop becomes the dominant cost.